### PR TITLE
User testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 cc-venv
 physiopy_*
+.repoignore
 
 # documention builds
 site/

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -42,6 +42,7 @@ class GitHubAPI:
         """
         self.org_name = org_name
         self.target_repo_name = target_repo_name
+        self.org_repos = [ ]
         self.target_filepath = target_filepath
         self.base_branch = base_branch
         self.head_branch = head_branch


### PR DESCRIPTION
# Purpose of the PR

To test the current capability of the code base - make suggested changes if bugs are found, and suggestions/enhancements as needed.

# Steps taken

## Set up

```
pip install hatch
hatch run all-all-contributors --help
```

```
set -a
source .env 
set +a
```

Inside .env there is INPUT_GITHUB_TOKEN=<my-token>

```
touch .repoignore 
```

Populate .repoignore  with physiopy repos that I know don't contain .all-contributorsrc files

## Run

```
hatch run all-all-contributors physiopy physiopy-automations .all-contributorsrc master merged-all
```

gave the error `AttributeError: 'GitHubAPI' object has no attribute 'org_repos'` so I tried to fix that in this commit https://github.com/the-turing-way/all-all-contributors/pull/79/commits/fc1cf38e702a07c9d3fa1abba4323c19f05aa244


```
hatch run all-all-contributors physiopy physiopy-automations .all-contributorsrc master merged-all
```

now runs without error but nothing happens ... (i.e. no print outputs and no branch created on the physiopy-automations repo with a merged contributor file)