### PR TITLE
fix: use proper docker invocation in action metadata file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,7 @@ inputs:
       Defaults to: merge-all-contributors
 runs:
   using: "docker"
-  image: "ghcr.io/the-turing-way/all-all-contributors:main"
+  image: "docker://ghcr.io/the-turing-way/all-all-contributors:main"
 branding:
   icon: "award"
   color: "blue"


### PR DESCRIPTION
Causes errors like the below without this prefix:

```
Error: 'ghcr.io/the-turing-way/all-all-contributors:main' should be either '[path]/Dockerfile' or 'docker://image[:tag]'.
```