### PR TITLE
fix: typo in outputs preventing docker tags being passed to build/push step

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -60,5 +60,5 @@ jobs:
           # Don't push builds to ghcr on pull requests
           # However, build will be always tested
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- potentially fixes #70 