### PR TITLE
fix: resolve runtime errors preventing action from executing

### DIFF
--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -94,7 +94,7 @@ def main(
 
     merged_contributors = merge_contributors(all_contributors)
     if merged_contributors:
-        github_api.run()
+        github_api.run(merged_contributors)
 
 
 def cli():

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -271,25 +271,25 @@ class GitHubAPI:
         resp = get_ref(resp["download_url"], headers=self.headers, output="json")
         return resp
 
-    def run(self) -> None:
+    def run(self, merged_contributors: list) -> None:
         """Run git flow to make a branch, commit a file, and open a PR"""
         # Check if a PR exists
-        github_api.find_existing_pull_request()
+        self.find_existing_pull_request()
 
         # We want to work against the most up-to-date version of the target file
-        if github_api.pr_exists:
+        if self.pr_exists:
             # If a PR exists, pull the file from there
-            file_contents = github_api.get_target_file_contents(github_api.head_branch)
+            file_contents = self.get_target_file_contents(self.head_branch)
         else:
             # Otherwise, pull from the base of the repo
-            file_contents = github_api.get_target_file_contents(github_api.base_branch)
+            file_contents = self.get_target_file_contents(self.base_branch)
 
         file_contents = inject_config(file_contents, merged_contributors)
 
-        if not github_api.pr_exists:
+        if not self.pr_exists:
             # Create a branch to open a PR from
-            resp = github_api.get_ref(github_api.base_branch)
-            github_api.create_ref(github_api.head_brach, resp["object"]["sha"])
+            resp = self.get_ref(self.base_branch)
+            self.create_ref(self.head_branch, resp["object"]["sha"])
 
         # base64 encode the updated config file
         encoded_file_contents = yaml.object_to_yaml_str(file_contents).encode("utf-8")
@@ -297,5 +297,5 @@ class GitHubAPI:
         file_contents = base64_bytes.decode("utf-8")
 
         # Create a commit and open a pull request
-        github_api.create_commit(file_contents)
-        github_api.create_update_pull_request()
+        self.create_commit(file_contents)
+        self.create_update_pull_request()


### PR DESCRIPTION
  - Fix AttributeError by using local variable 'org_repos' instead of 'self.org_repos'
  - Handle missing .all-contributorsrc files gracefully with 404 error handling
  - Fix TypeError by using extend() instead of append() to build flat contributor list
  - Fix NameError in run() method by using 'self' for instance method calls
  - Add merged_contributors parameter to run() method signature
  - Fix typo: head_brach -> head_branch
  - Add missing requests import for HTTPError exception handling
  - Update README to reflect github_token is a required input