### PR TITLE
refactor: use local git operations instead of GitHub API calls

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,48 @@
-# Folders to be ignored
+# Version control
 .git
 .github
-docs
-old-code
-tests
 
-# Files to be ignored
-.all-contributorsrc
+# Documentation
+docs
 mkdocs.yml
+
+# Tests
+tests
+.pytest_cache
+.coverage
+
+# Python virtual environments and caches
+.venv
+venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.so
+*.egg
+*.egg-info
+dist
+build
+.eggs
+
+# Python tools caches
+.ruff_cache
+.hatch
+.mypy_cache
+.tox
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Config files
+.all-contributorsrc
+.pre-commit-config.yaml
+
+# Logs
+*.log

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        # TEMPORARY: Commented out to allow PR builds
+        # if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -36,7 +37,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        if: github.event_name != 'pull_request'
+        # TEMPORARY: Commented out to allow PR builds
+        # if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -53,12 +55,16 @@ jobs:
             type=sha
             # The latest commit of the pushed to branch, using the branch name as a tag
             type=ref,event=branch
+            # TEMPORARY: Tag PRs with 'test' for testing
+            type=raw,value=test,enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push image to registry
         uses: docker/build-push-action@v7
         with:
+          # TEMPORARY: Changed to allow PR builds with 'test' tag
           # Don't push builds to ghcr on pull requests
           # However, build will be always tested
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Login to GitHub Container Registry
-        # TEMPORARY: Commented out to allow PR builds
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -37,8 +36,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        # TEMPORARY: Commented out to allow PR builds
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -55,16 +53,12 @@ jobs:
             type=sha
             # The latest commit of the pushed to branch, using the branch name as a tag
             type=ref,event=branch
-            # TEMPORARY: Tag PRs with 'test' for testing
-            type=raw,value=test,enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push image to registry
         uses: docker/build-push-action@v7
         with:
-          # TEMPORARY: Changed to allow PR builds with 'test' tag
           # Don't push builds to ghcr on pull requests
           # However, build will be always tested
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@
 # Use a Python slim image
 FROM python:3.14.6-slim
 
-# Install gcc
-# NOTE: Sarah can't remember why she needed this line... Let's see what breaks without it!
-# RUN apt-get update && apt-get install --yes gcc
+# Install git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 # Create and set the 'app' working directory
 RUN mkdir /app

--- a/README.md
+++ b/README.md
@@ -23,6 +23,50 @@ This project will provide a way to fetch all of the `.all-contributorsrc` files 
 
 ## Usage
 
+### Prerequisites
+
+This action requires:
+1. **Repository Checkout**: The target repository must be checked out before running this action using `actions/checkout@v4`
+2. **Git Configuration**: Git user name and email must be configured for commits
+3. **Git Authentication**: Authentication is handled automatically by `actions/checkout` when you pass the `token` parameter
+
+### Example Workflow
+
+```yaml
+name: Merge All Contributors
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
+  workflow_dispatch:     # Allow manual triggering
+  workflow_call:         # Allow other workflows to call this one
+
+jobs:
+  merge-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge all contributors
+        uses: the-turing-way/all-all-contributors@main
+        with:
+          organisation: your-org-name
+          target_repo: your-repo-name
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Inputs
 
 | Input Name | Input Description | Required? |
@@ -30,9 +74,10 @@ This project will provide a way to fetch all of the `.all-contributorsrc` files 
 | `organisation` | The name of the GitHub organisation to collect all-contributors from | **YES** |
 | `target_repo` | The name of the repository within the GitHub organisation where the merged all-contributors file will live | **YES** |
 | `github_token` | A GitHub token with permissions to write to the contents of the target repo and open pull requests. | **YES** |
-| `target_filepath` | Path to a plain text file containing a list of repos within the organisation to exclude from the merge. Defaults to: `.repoignore`. | no |
+| `target_filepath` | Path to the merged all-contributors file relative to the repository root. Defaults to: `.all-contributorsrc`. | no |
 | `base_branch` | The name of the branch on the target repo to open pull requests against. Defaults to: `main`. | no |
 | `head_branch` | A prefix to prepend to head branches when opening pull requests. Defaults to: `merge-all-contributors`. | no |
+| `working_dir` | Path to the checked-out git repository. Defaults to: `.` (current directory). | no |
 
 ### Permissions
 

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ inputs:
       in actions/checkout if a custom path was specified. Defaults to: . (current directory)
 runs:
   using: "docker"
-  image: "docker://ghcr.io/the-turing-way/all-all-contributors:main"
+  image: "docker://ghcr.io/the-turing-way/all-all-contributors:test"
 branding:
   icon: "award"
   color: "blue"

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ description: >-
   from repos within an organisation and opens a Pull Request to a chosen repo to
   host the full list of contributors in.
 
+  IMPORTANT: This action requires the repository to be checked out first using
+  actions/checkout@v4. Git authentication is handled automatically by actions/checkout
+  when you pass the token parameter. See the README for complete usage examples.
+
   Developed at the Software Sustainability Institute's Collaboration Workshop
   hackday in 2025 (https://www.software.ac.uk/workshop/collaborations-workshop-2025-cw25).
 inputs:
@@ -37,6 +41,10 @@ inputs:
     description: >-
       A prefix to prepend to head branches when opening pull requests.
       Defaults to: merge-all-contributors
+  working_dir:
+    description: >-
+      Path to the checked-out git repository. This should match the path used
+      in actions/checkout if a custom path was specified. Defaults to: . (current directory)
 runs:
   using: "docker"
   image: "docker://ghcr.io/the-turing-way/all-all-contributors:main"

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ inputs:
       in actions/checkout if a custom path was specified. Defaults to: . (current directory)
 runs:
   using: "docker"
-  image: "docker://ghcr.io/the-turing-way/all-all-contributors:test"
+  image: "docker://ghcr.io/the-turing-way/all-all-contributors:main"
 branding:
   icon: "award"
   color: "blue"

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -13,15 +13,6 @@ from .merge import merge_contributors
 app = typer.Typer(pretty_exceptions_show_locals=False)
 
 
-def get_github_token() -> str | None:
-    """Read a GitHub token from the environment"""
-    token = getenv("INPUT_GITHUB_TOKEN")
-    if token is None:
-        print("Environment variable INPUT_GITHUB_TOKEN is not defined")
-        raise typer.Exit(code=1)
-    return token
-
-
 def load_excluded_repos() -> set:
     """Load excluded repositories from a file
 
@@ -55,6 +46,13 @@ def main(
             help="Target repository where the merged .all-contributorsrc file exists",
         ),
     ],
+    github_token: Annotated[
+        str,
+        typer.Argument(
+            envvar="INPUT_GITHUB_TOKEN",
+            help="GitHub personal access token with `public_repo` and `repo` permissions",
+        ),
+    ],
     target_filepath: Annotated[
         str,
         typer.Argument(
@@ -76,15 +74,7 @@ def main(
             help="The name of the head branch to create in the target repository to open a Pull Request",
         ),
     ] = "merged-all-contributors",
-    working_dir: Annotated[
-        str,
-        typer.Argument(
-            envvar="INPUT_WORKING_DIR",
-            help="Path to the checked-out git repository",
-        ),
-    ] = ".",
 ) -> None:
-    github_token = get_github_token()
     excluded_repos = load_excluded_repos()
 
     # Fetch all repos from the organization

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -60,6 +60,13 @@ def main(
             help="Target filepath where the merged .all-contributorsrc will be written",
         ),
     ] = ".all-contributorsrc",
+    working_dir: Annotated[
+        str,
+        typer.Argument(
+            envvar="INPUT_WORKING_DIR",
+            help="Path to the checked-out git repository",
+        ),
+    ] = ".",
     base_branch: Annotated[
         str,
         typer.Argument(

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -150,12 +150,12 @@ def main(
     print(f"Updated {target_filepath} with merged contributors")
 
     # Check if there are any changes to commit
-    if not git_operations.has_changes(working_dir):
+    if not git_operations.has_changes(working_dir, target_filepath):
         print("No changes to commit - contributors list is already up to date")
         return
 
-    # Stage modified files (ignores untracked files)
-    git_operations.stage_modified_files(working_dir)
+    # Stage the specific file we modified
+    git_operations.stage_modified_files(working_dir, target_filepath)
 
     # Create commit
     commit_message = "Merging all contributors info from across the org"

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -147,16 +147,19 @@ def main(
     with open(config_path, "w") as f:
         json.dump(file_contents, f, indent=2)
         f.write("\n")  # Add trailing newline
-
     print(f"Updated {target_filepath} with merged contributors")
-
-    # Stage modified files (ignores untracked files)
-    git_operations.stage_modified_files(working_dir)
 
     # Check if there are any changes to commit
     if not git_operations.has_changes(working_dir):
         print("No changes to commit - contributors list is already up to date")
         return
+
+    # Stage modified files (ignores untracked files)
+    git_operations.stage_modified_files(working_dir)
+
+    # Create commit
+    commit_message = "Merging all contributors info from across the org"
+    git_operations.create_commit(commit_message, working_dir)
 
     # Push branch to remote
     git_operations.push_branch(head_branch, working_dir)

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -127,7 +127,7 @@ def main(
     except FileNotFoundError:
         print(f"File {target_filepath} not found, creating with default structure")
         file_contents = {
-            "files": ["profile/README.md"],
+            "files": ["README.md"],
             "imageSize": 100,
             "commit": False,
             "commitConvention": "angular",

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -9,7 +9,8 @@ from . import git_operations, github_api
 from .inject import inject_config
 from .merge import merge_contributors
 
-app = typer.Typer()
+# Disable pretty exceptions exposing sensitive data in error messages
+app = typer.Typer(pretty_exceptions_show_locals=False)
 
 
 def get_github_token() -> str | None:

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -109,7 +109,9 @@ def main(
     )
 
     # Check if branch exists on remote
-    branch_exists = git_operations.branch_exists_remote(actual_head_branch, working_dir)
+    branch_exists, actual_head_branch = git_operations.branch_exists_remote(
+        actual_head_branch, working_dir
+    )
 
     if branch_exists:
         # Checkout existing branch and pull latest changes

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -161,9 +161,10 @@ def main(
     # Stage modified files (ignores untracked files)
     git_operations.stage_modified_files(working_dir)
 
-    # Create commit
-    commit_message = "Merging all contributors info from across the org"
-    git_operations.create_commit(commit_message, working_dir)
+    # Check if there are any changes to commit
+    if not git_operations.has_changes(working_dir):
+        print("No changes to commit - contributors list is already up to date")
+        return
 
     # Push branch to remote
     git_operations.push_branch(actual_head_branch, working_dir)

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import typer
 
 from . import git_operations, github_api
-from .inject import inject_config
+from .inject import inject_config, load_config_file, write_config_file
 from .merge import merge_contributors
 
 # Disable pretty exceptions exposing sensitive data in error messages
@@ -90,67 +90,30 @@ def main(
     # Fetch all repos from the organization
     repos = github_api.get_all_repos(organisation, github_token, excluded_repos)
 
-    # Fetch contributors from all repos
-    all_contributors = []
-    for repo in repos:
-        contributors = github_api.get_contributors_from_repo(
-            organisation, repo, github_token
-        )
-        all_contributors.extend(contributors)
-
-    # Merge contributors
+    # Fetch and merge contributors from all repos
+    all_contributors = github_api.fetch_all_contributors(
+        organisation, github_token, repos
+    )
     merged_contributors = merge_contributors(all_contributors)
     if not merged_contributors:
         print("No contributors to merge")
         return
 
-    # Check if PR already exists
+    # Check if PR already exists and checkout appropriate branch
     pr_exists, head_branch, pr_number = github_api.find_existing_pull_request(
         organisation, target_repo, head_branch, github_token
     )
+    git_operations.checkout_branch(
+        head_branch, create=not pr_exists, working_dir=working_dir
+    )
 
-    if pr_exists:
-        # Checkout existing branch
-        print(f"Branch {head_branch} exists, checking out")
-        git_operations.checkout_branch(
-            head_branch, create=False, working_dir=working_dir
-        )
-    else:
-        # Create new branch from current position
-        print(f"Creating new branch: {head_branch}")
-        git_operations.checkout_branch(
-            head_branch, create=True, working_dir=working_dir
-        )
-
-    # Read local .all-contributorsrc file
+    # Load, update, and write config file
     config_path = os.path.join(working_dir, target_filepath)
-    try:
-        with open(config_path, "r") as f:
-            file_contents = json.load(f)
-    except FileNotFoundError:
-        print(f"File {target_filepath} not found, creating with default structure")
-        file_contents = {
-            "files": ["README.md"],
-            "imageSize": 100,
-            "commit": False,
-            "commitConvention": "angular",
-            "contributors": [],
-            "contributorsPerLine": 7,
-            "skipCi": True,
-            "repoType": "github",
-            "repoHost": "https://github.com",
-            "projectName": target_repo,
-            "projectOwner": organisation,
-        }
-
-    # Inject merged contributors
+    file_contents = load_config_file(
+        config_path, target_filepath, organisation, target_repo
+    )
     file_contents = inject_config(file_contents, merged_contributors)
-
-    # Write updated .all-contributorsrc to local filesystem
-    with open(config_path, "w") as f:
-        json.dump(file_contents, f, indent=2)
-        f.write("\n")  # Add trailing newline
-    print(f"Updated {target_filepath} with merged contributors")
+    write_config_file(config_path, file_contents, target_filepath)
 
     # Check if there are any changes to commit
     if not git_operations.has_changes(working_dir, target_filepath):

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -1,11 +1,12 @@
-import base64
-
+import json
+import os
 from os import getenv, path
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 
-from .github_api import GitHubAPI
+from . import git_operations, github_api
+from .inject import inject_config
 from .merge import merge_contributors
 
 app = typer.Typer()
@@ -56,45 +57,125 @@ def main(
     target_filepath: Annotated[
         str,
         typer.Argument(
-            envvar="AAC_TARGET_FILEPATH",
+            envvar="INPUT_TARGET_FILEPATH",
             help="Target filepath where the merged .all-contributorsrc will be written",
         ),
     ] = ".all-contributorsrc",
     base_branch: Annotated[
         str,
         typer.Argument(
-            envvar="AAC_BASE_BRANCH",
+            envvar="INPUT_BASE_BRANCH",
             help="The name of the default branch of the target repository",
         ),
     ] = "main",
     head_branch: Annotated[
         str,
         typer.Argument(
-            envvar="AAC_HEAD_BRANCH",
+            envvar="INPUT_HEAD_BRANCH",
             help="The name of the head branch to create in the target repository to open a Pull Request",
         ),
     ] = "merged-all-contributors",
+    working_dir: Annotated[
+        str,
+        typer.Argument(
+            envvar="INPUT_WORKING_DIR",
+            help="Path to the checked-out git repository",
+        ),
+    ] = ".",
 ) -> None:
     github_token = get_github_token()
     excluded_repos = load_excluded_repos()
 
-    github_api = GitHubAPI(
-        organisation,
-        target_repo,
-        github_token,
-        target_filepath=target_filepath,
-        base_branch=base_branch,
-    )
-    repos = github_api.get_all_repos(excluded_repos)
+    # Fetch all repos from the organization
+    repos = github_api.get_all_repos(organisation, github_token, excluded_repos)
 
+    # Fetch contributors from all repos
     all_contributors = []
     for repo in repos:
-        contributors = github_api.get_contributors_from_repo(repo)
+        contributors = github_api.get_contributors_from_repo(
+            organisation, repo, github_token
+        )
         all_contributors.extend(contributors)
 
+    # Merge contributors
     merged_contributors = merge_contributors(all_contributors)
-    if merged_contributors:
-        github_api.run(merged_contributors)
+    if not merged_contributors:
+        print("No contributors to merge")
+        return
+
+    # Check if PR already exists
+    pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
+        organisation, target_repo, head_branch, github_token
+    )
+
+    # Check if branch exists on remote
+    branch_exists = git_operations.branch_exists_remote(actual_head_branch, working_dir)
+
+    if branch_exists:
+        # Checkout existing branch and pull latest changes
+        print(f"Branch {actual_head_branch} exists, checking out and pulling latest")
+        git_operations.checkout_branch(
+            actual_head_branch, create=False, working_dir=working_dir
+        )
+        git_operations.pull_latest(working_dir)
+    else:
+        # Create new branch from current position
+        print(f"Creating new branch: {actual_head_branch}")
+        git_operations.checkout_branch(
+            actual_head_branch, create=True, working_dir=working_dir
+        )
+
+    # Read local .all-contributorsrc file
+    config_path = os.path.join(working_dir, target_filepath)
+    try:
+        with open(config_path, "r") as f:
+            file_contents = json.load(f)
+    except FileNotFoundError:
+        print(f"File {target_filepath} not found, creating with default structure")
+        file_contents = {
+            "files": ["profile/README.md"],
+            "imageSize": 100,
+            "commit": False,
+            "commitConvention": "angular",
+            "contributors": [],
+            "contributorsPerLine": 7,
+            "skipCi": True,
+            "repoType": "github",
+            "repoHost": "https://github.com",
+            "projectName": target_repo,
+            "projectOwner": organisation,
+        }
+
+    # Inject merged contributors
+    file_contents = inject_config(file_contents, merged_contributors)
+
+    # Write updated .all-contributorsrc to local filesystem
+    with open(config_path, "w") as f:
+        json.dump(file_contents, f, indent=2)
+        f.write("\n")  # Add trailing newline
+
+    print(f"Updated {target_filepath} with merged contributors")
+
+    # Stage modified files (ignores untracked files)
+    git_operations.stage_modified_files(working_dir)
+
+    # Create commit
+    commit_message = "Merging all contributors info from across the org"
+    git_operations.create_commit(commit_message, working_dir)
+
+    # Push branch to remote
+    git_operations.push_branch(actual_head_branch, working_dir)
+
+    # Create or update pull request
+    github_api.create_update_pull_request(
+        organisation,
+        target_repo,
+        base_branch,
+        actual_head_branch,
+        pr_exists,
+        pr_number,
+        github_token,
+    )
 
 
 def cli():

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -80,7 +80,7 @@ def main(
             envvar="INPUT_HEAD_BRANCH",
             help="The name of the head branch to create in the target repository to open a Pull Request",
         ),
-    ] = "merged-all-contributors",
+    ] = "merge-all-contributors",
 ) -> None:
     excluded_repos = load_excluded_repos()
 

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -82,6 +82,9 @@ def main(
         ),
     ] = "merge-all-contributors",
 ) -> None:
+    # Configure git safe.directory to handle ownership issues in CI
+    git_operations.configure_safe_directory(working_dir)
+
     excluded_repos = load_excluded_repos()
 
     # Fetch all repos from the organization

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -105,27 +105,21 @@ def main(
         return
 
     # Check if PR already exists
-    pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
+    pr_exists, head_branch, pr_number = github_api.find_existing_pull_request(
         organisation, target_repo, head_branch, github_token
     )
 
-    # Check if branch exists on remote
-    branch_exists, actual_head_branch = git_operations.branch_exists_remote(
-        actual_head_branch, working_dir
-    )
-
-    if branch_exists:
-        # Checkout existing branch and pull latest changes
-        print(f"Branch {actual_head_branch} exists, checking out and pulling latest")
+    if pr_exists:
+        # Checkout existing branch
+        print(f"Branch {head_branch} exists, checking out")
         git_operations.checkout_branch(
-            actual_head_branch, create=False, working_dir=working_dir
+            head_branch, create=False, working_dir=working_dir
         )
-        git_operations.pull_latest(working_dir)
     else:
         # Create new branch from current position
-        print(f"Creating new branch: {actual_head_branch}")
+        print(f"Creating new branch: {head_branch}")
         git_operations.checkout_branch(
-            actual_head_branch, create=True, working_dir=working_dir
+            head_branch, create=True, working_dir=working_dir
         )
 
     # Read local .all-contributorsrc file
@@ -168,14 +162,14 @@ def main(
         return
 
     # Push branch to remote
-    git_operations.push_branch(actual_head_branch, working_dir)
+    git_operations.push_branch(head_branch, working_dir)
 
     # Create or update pull request
     github_api.create_update_pull_request(
         organisation,
         target_repo,
         base_branch,
-        actual_head_branch,
+        head_branch,
         pr_exists,
         pr_number,
         github_token,

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -51,6 +51,20 @@ def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
             raise
     else:
         print(f"Checking out existing branch: {branch_name}")
+        # First, fetch the remote branch in case it exists remotely but not locally
+        try:
+            subprocess.run(
+                ["git", "fetch", "origin", branch_name],
+                cwd=working_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git fetch failed with error:\n{e.stderr}")
+            # Continue anyway - the branch might exist locally
+
+        # Try to checkout the branch
         try:
             subprocess.run(
                 ["git", "checkout", branch_name],
@@ -60,8 +74,19 @@ def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
                 text=True,
             )
         except subprocess.CalledProcessError as e:
-            print(f"Git checkout failed with error:\n{e.stderr}")
-            raise
+            # If checkout failed, try to checkout with remote tracking
+            print(f"Local checkout failed, trying remote tracking")
+            try:
+                subprocess.run(
+                    ["git", "checkout", "--track", f"origin/{branch_name}"],
+                    cwd=working_dir,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e2:
+                print(f"Git checkout failed with error:\n{e2.stderr}")
+                raise
 
 
 def stage_modified_files(working_dir: str, filepath: str = None) -> None:

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -31,38 +31,53 @@ def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
         )
 
 
-def stage_modified_files(working_dir: str) -> None:
+def stage_modified_files(working_dir: str, filepath: str = None) -> None:
     """
-    Stage all modified files (ignores untracked files).
-
-    Uses: git add --update
+    Stage modified files.
 
     Args:
         working_dir: Repository working directory
+        filepath: Optional specific file to stage. If provided, stages that file.
+                  If None, stages all tracked modified files.
     """
-    print("Staging modified files")
+    if filepath:
+        print(f"Staging file: {filepath}")
+        subprocess.run(
+            ["git", "add", filepath],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        print("Staging modified files")
+        subprocess.run(
+            ["git", "add", "--update"],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
-    subprocess.run(
-        ["git", "add", "--update"],
-        cwd=working_dir,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
 
-
-def has_changes(working_dir: str) -> bool:
+def has_changes(working_dir: str, filepath: str = None) -> bool:
     """
     Check if there are any changes ready to be staged and committed.
 
     Args:
         working_dir: Repository working directory
+        filepath: Optional specific file to check. If provided, only checks that file.
+                  If None, checks all files.
 
     Returns:
         bool: True if there are local changes, False otherwise
     """
+    cmd = ["git", "diff", "--quiet"]
+    if filepath:
+        cmd.append(filepath)
+
     result = subprocess.run(
-        ["git", "diff", "--quiet"],
+        cmd,
         cwd=working_dir,
         capture_output=True,
         text=True,

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -2,19 +2,45 @@ import os
 import subprocess
 
 
-def branch_exists_remote(branch_name: str, working_dir: str) -> bool:
+def branch_exists_remote(branch_name: str, working_dir: str) -> tuple[bool, str]:
     """
-    Check if branch exists on remote.
+    Check if branch exists on remote. If branch_name contains a prefix pattern
+    (e.g., "merged-all-contributors/aBcD"), it will also check for any existing
+    branches matching the prefix (e.g., "merged-all-contributors/*").
 
     Args:
-        branch_name: Name of the branch to check
+        branch_name: Name of the branch to check (may include random suffix)
         working_dir: Repository working directory
 
     Returns:
-        bool: True if branch exists on remote, False otherwise
+        tuple: (exists, actual_branch_name)
+            exists: True if a matching branch exists on remote, False otherwise
+            actual_branch_name: The actual branch name if found, otherwise the input branch_name
     """
-    print(f"Checking if branch {branch_name} exists on remote")
+    # Extract prefix if branch_name contains a separator
+    if "/" in branch_name:
+        prefix = branch_name.rsplit("/", 1)[0]
+        print(f"Checking if any branch matching '{prefix}/*' exists on remote")
 
+        # List all remote branches with the prefix
+        result = subprocess.run(
+            ["git", "ls-remote", "--heads", "origin", f"{prefix}/*"],
+            cwd=working_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        if result.stdout.strip():
+            # Extract the first matching branch name from output
+            # Output format: <hash>\trefs/heads/<branch_name>
+            first_line = result.stdout.strip().split("\n")[0]
+            actual_branch = first_line.split("\t")[1].replace("refs/heads/", "")
+            print(f"Found existing branch: {actual_branch}")
+            return True, actual_branch
+
+    # Fall back to exact match check
+    print(f"Checking if branch {branch_name} exists on remote")
     result = subprocess.run(
         ["git", "ls-remote", "--heads", "origin", branch_name],
         cwd=working_dir,
@@ -23,8 +49,10 @@ def branch_exists_remote(branch_name: str, working_dir: str) -> bool:
         check=True,
     )
 
-    # If output is not empty, branch exists
-    return len(result.stdout.strip()) > 0
+    if result.stdout.strip():
+        return True, branch_name
+
+    return False, branch_name
 
 
 def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -13,22 +13,30 @@ def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
     """
     if create:
         print(f"Creating and checking out new branch: {branch_name}")
-        subprocess.run(
-            ["git", "checkout", "-b", branch_name],
-            cwd=working_dir,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                ["git", "checkout", "-b", branch_name],
+                cwd=working_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git checkout failed with error:\n{e.stderr}")
+            raise
     else:
         print(f"Checking out existing branch: {branch_name}")
-        subprocess.run(
-            ["git", "checkout", branch_name],
-            cwd=working_dir,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                ["git", "checkout", branch_name],
+                cwd=working_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git checkout failed with error:\n{e.stderr}")
+            raise
 
 
 def stage_modified_files(working_dir: str, filepath: str = None) -> None:
@@ -42,22 +50,30 @@ def stage_modified_files(working_dir: str, filepath: str = None) -> None:
     """
     if filepath:
         print(f"Staging file: {filepath}")
-        subprocess.run(
-            ["git", "add", filepath],
-            cwd=working_dir,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                ["git", "add", filepath],
+                cwd=working_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git add failed with error:\n{e.stderr}")
+            raise
     else:
         print("Staging modified files")
-        subprocess.run(
-            ["git", "add", "--update"],
-            cwd=working_dir,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            subprocess.run(
+                ["git", "add", "--update"],
+                cwd=working_dir,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"Git add failed with error:\n{e.stderr}")
+            raise
 
 
 def has_changes(working_dir: str, filepath: str = None) -> bool:
@@ -97,13 +113,17 @@ def create_commit(message: str, working_dir: str) -> None:
     """
     print(f"Creating commit with message: {message}")
 
-    subprocess.run(
-        ["git", "commit", "-m", message],
-        cwd=working_dir,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            ["git", "commit", "-m", message],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Git commit failed with error:\n{e.stderr}")
+        raise
 
 
 def push_branch(branch_name: str, working_dir: str) -> None:
@@ -116,10 +136,14 @@ def push_branch(branch_name: str, working_dir: str) -> None:
     """
     print(f"Pushing branch {branch_name} to remote")
 
-    subprocess.run(
-        ["git", "push", "origin", branch_name],
-        cwd=working_dir,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        subprocess.run(
+            ["git", "push", "origin", branch_name],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Git push failed with error:\n{e.stderr}")
+        raise

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -2,59 +2,6 @@ import os
 import subprocess
 
 
-def branch_exists_remote(branch_name: str, working_dir: str) -> tuple[bool, str]:
-    """
-    Check if branch exists on remote. If branch_name contains a prefix pattern
-    (e.g., "merged-all-contributors/aBcD"), it will also check for any existing
-    branches matching the prefix (e.g., "merged-all-contributors/*").
-
-    Args:
-        branch_name: Name of the branch to check (may include random suffix)
-        working_dir: Repository working directory
-
-    Returns:
-        tuple: (exists, actual_branch_name)
-            exists: True if a matching branch exists on remote, False otherwise
-            actual_branch_name: The actual branch name if found, otherwise the input branch_name
-    """
-    # Extract prefix if branch_name contains a separator
-    if "/" in branch_name:
-        prefix = branch_name.rsplit("/", 1)[0]
-        print(f"Checking if any branch matching '{prefix}/*' exists on remote")
-
-        # List all remote branches with the prefix
-        result = subprocess.run(
-            ["git", "ls-remote", "--heads", "origin", f"{prefix}/*"],
-            cwd=working_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        if result.stdout.strip():
-            # Extract the first matching branch name from output
-            # Output format: <hash>\trefs/heads/<branch_name>
-            first_line = result.stdout.strip().split("\n")[0]
-            actual_branch = first_line.split("\t")[1].replace("refs/heads/", "")
-            print(f"Found existing branch: {actual_branch}")
-            return True, actual_branch
-
-    # Fall back to exact match check
-    print(f"Checking if branch {branch_name} exists on remote")
-    result = subprocess.run(
-        ["git", "ls-remote", "--heads", "origin", branch_name],
-        cwd=working_dir,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-    if result.stdout.strip():
-        return True, branch_name
-
-    return False, branch_name
-
-
 def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
     """
     Checkout branch, optionally creating it if it doesn't exist.
@@ -82,24 +29,6 @@ def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
             capture_output=True,
             text=True,
         )
-
-
-def pull_latest(working_dir: str) -> None:
-    """
-    Pull latest changes from remote for current branch.
-
-    Args:
-        working_dir: Repository working directory
-    """
-    print("Pulling latest changes from remote")
-
-    subprocess.run(
-        ["git", "pull"],
-        cwd=working_dir,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
 
 
 def stage_modified_files(working_dir: str) -> None:

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -2,6 +2,31 @@ import os
 import subprocess
 
 
+def configure_safe_directory(working_dir: str) -> None:
+    """
+    Configure git safe.directory to allow operations in this repository.
+
+    This is needed in CI environments where the repository may have different
+    ownership than the user running git commands.
+
+    Args:
+        working_dir: Repository working directory
+    """
+    # Convert to absolute path since git config expects absolute paths
+    abs_working_dir = os.path.abspath(working_dir)
+
+    try:
+        subprocess.run(
+            ["git", "config", "--global", "--add", "safe.directory", abs_working_dir],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Git config safe.directory failed with error:\n{e.stderr}")
+        raise
+
+
 def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
     """
     Checkout branch, optionally creating it if it doesn't exist.

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -122,6 +122,27 @@ def stage_modified_files(working_dir: str) -> None:
     )
 
 
+def has_changes(working_dir: str) -> bool:
+    """
+    Check if there are any changes ready to be staged and committed.
+
+    Args:
+        working_dir: Repository working directory
+
+    Returns:
+        bool: True if there are local changes, False otherwise
+    """
+    result = subprocess.run(
+        ["git", "diff", "--quiet"],
+        cwd=working_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    # git diff --quiet returns 0 if no changes, 1 if there are changes
+    return result.returncode == 1
+
+
 def create_commit(message: str, working_dir: str) -> None:
     """
     Create a git commit.

--- a/all_all_contributors/git_operations.py
+++ b/all_all_contributors/git_operations.py
@@ -1,0 +1,132 @@
+import os
+import subprocess
+
+
+def branch_exists_remote(branch_name: str, working_dir: str) -> bool:
+    """
+    Check if branch exists on remote.
+
+    Args:
+        branch_name: Name of the branch to check
+        working_dir: Repository working directory
+
+    Returns:
+        bool: True if branch exists on remote, False otherwise
+    """
+    print(f"Checking if branch {branch_name} exists on remote")
+
+    result = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", branch_name],
+        cwd=working_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # If output is not empty, branch exists
+    return len(result.stdout.strip()) > 0
+
+
+def checkout_branch(branch_name: str, create: bool, working_dir: str) -> None:
+    """
+    Checkout branch, optionally creating it if it doesn't exist.
+
+    Args:
+        branch_name: Name of the branch to checkout
+        create: Whether to create the branch if it doesn't exist
+        working_dir: Repository working directory
+    """
+    if create:
+        print(f"Creating and checking out new branch: {branch_name}")
+        subprocess.run(
+            ["git", "checkout", "-b", branch_name],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        print(f"Checking out existing branch: {branch_name}")
+        subprocess.run(
+            ["git", "checkout", branch_name],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def pull_latest(working_dir: str) -> None:
+    """
+    Pull latest changes from remote for current branch.
+
+    Args:
+        working_dir: Repository working directory
+    """
+    print("Pulling latest changes from remote")
+
+    subprocess.run(
+        ["git", "pull"],
+        cwd=working_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def stage_modified_files(working_dir: str) -> None:
+    """
+    Stage all modified files (ignores untracked files).
+
+    Uses: git add --update
+
+    Args:
+        working_dir: Repository working directory
+    """
+    print("Staging modified files")
+
+    subprocess.run(
+        ["git", "add", "--update"],
+        cwd=working_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def create_commit(message: str, working_dir: str) -> None:
+    """
+    Create a git commit.
+
+    Args:
+        message: Commit message
+        working_dir: Repository working directory
+    """
+    print(f"Creating commit with message: {message}")
+
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=working_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def push_branch(branch_name: str, working_dir: str) -> None:
+    """
+    Push branch to remote (not force push).
+
+    Args:
+        branch_name: Name of the branch to push
+        working_dir: Repository working directory
+    """
+    print(f"Pushing branch {branch_name} to remote")
+
+    subprocess.run(
+        ["git", "push", "origin", branch_name],
+        cwd=working_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -1,5 +1,3 @@
-import os
-import base64
 import json
 import random
 import string
@@ -7,210 +5,178 @@ import jmespath
 import requests
 
 from .http_requests import get_request, patch_request, post_request
-from .inject import inject_config
-from .yaml_parser import YamlParser
 
-yaml = YamlParser()
+API_URL = "https://api.github.com"
 
 
-class GitHubAPI:
-    """Interact with the GitHub API and perform various git-flow tasks"""
+def _get_headers(github_token: str) -> dict:
+    """Get headers for GitHub API requests"""
+    return {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": f"token {github_token}",
+    }
 
-    def __init__(
-        self,
-        org_name: str,
-        target_repo_name: str,
-        github_token: str,
-        target_filepath: str = ".all-contributorsrc",
-        base_branch: str = "main",
-        head_branch: str = "merge-all-contributors",
-    ):
-        """
-        Args:
-            org_name (str): The name of the GitHub organisation to target
-            target_repo_name (str): The name of the repo within `org_name` that
-                will host the combined .all-contributorsrc file
-            github_token (str): A GitHub token to authenticate API calls
-            target_filepath (str, optional): The filepath within `target_repo_name`
-                to the combined `.all-contributorsrc` file.
-                (default: ".all-contributorsrc")
-            base_branch (str, optional): The name of the default branch in
-                `target_repo_name`. (default: "main")
-            head_branch (str, optional): A prefix for branches created in
-                `target_repo_name` for pull requests.
-                (default: "all-all-contributors")
-        """
-        self.org_name = org_name
-        self.target_repo_name = target_repo_name
-        self.target_filepath = target_filepath
-        self.base_branch = base_branch
-        self.head_branch = head_branch
 
-        self.headers = {
-            "Accept": "application/vnd.github.v3+json",
-            "Authorization": f"token {github_token}",
-        }
+def get_all_repos(org_name: str, github_token: str, excluded_repos: list) -> list:
+    """
+    Get all repositories from a GitHub organization using the GitHub API
 
-        self.api_url = "https://api.github.com"
+    Args:
+        org_name: The name of the GitHub organisation
+        github_token: GitHub token for authentication
+        excluded_repos: A list of excluded repos to skip
 
-    def create_update_pull_request(self):
-        """Create or update a Pull Request via the GitHub API"""
-        url = "/".join(
-            [self.api_url, "repos", self.org_name, self.target_repo_name, "pulls"]
+    Returns:
+        list: A list of remaining repos in the organisation
+    """
+    headers = _get_headers(github_token)
+    org_repos = []
+
+    # First API call
+    url = "/".join([API_URL, "orgs", org_name, "repos"])
+    params = {"type": "public", "per_page": 100}
+    resp = get_request(url, headers=headers, params=params)
+    for repo in resp.json():
+        if repo["name"] not in excluded_repos:
+            org_repos.append(repo["name"])
+
+    # Paginate over results using the 'link' and rel['next'] parameters from
+    # the API response
+    # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
+    while "link" in resp.headers:
+        resp = get_request(
+            resp.links["next"]["url"], headers=headers, params=params
         )
-        pr = {
-            "title": "Merging all-contributors across the org",
-            "body": "",  # FIXME: Add a descriptove PR body here
-            "base": self.base_branch,
-        }
-
-        if self.pr_exists:
-            print("Updating Pull Request...")
-
-            url = "/".join([url, str(self.pr_number)])
-            pr["state"] = "open"
-            resp = patch_request(
-                url,
-                headers=self.headers,
-                json=pr,
-                return_json=True,
-            )
-
-            print(f"Pull Request #{resp['number']} updated!")
-        else:
-            print("Creating Pull Request...")
-
-            pr["head"] = self.head_branch
-            resp = post_request(
-                url,
-                headers=self.headers,
-                json=pr,
-                return_json=True,
-            )
-
-            print(f"Pull Request #{resp['number']} created!")
-
-    def find_existing_pull_request(self):
-        """Check if the bot already has an open Pull Request"""
-        print("Finding Pull Requests previously opened to merge all contributors files")
-
-        url = "/".join(
-            [self.api_url, "repos", self.org_name, self.target_repo_name, "pulls"]
-        )
-        params = {"state": "open", "sort": "created", "direction": "desc"}
-        resp = get_request(url, headers=self.headers, params=params, output="json")
-
-        # Expression to match the head ref
-        matches = jmespath.search("[*].head.label", resp)
-        indx, match = next(
-            (
-                (indx, match)
-                for (indx, match) in enumerate(matches)
-                if self.head_branch in match
-            ),
-            (None, None),
-        )
-
-        if (indx is None) and (match is None):
-            print("No relevant Pull Requests found. A new Pull Request will be opened.")
-            random_id = "".join(random.sample(string.ascii_letters, 4))
-            self.head_branch = "/".join([self.head_branch, random_id])
-            self.pr_exists = False
-        else:
-            print(
-                "Relevant Pull Request found. Will push new commits to this Pull Request."
-            )
-
-            self.head_branch = match.split(":")[-1]
-            self.pr_number = resp[indx]["number"]
-            self.pr_exists = True
-
-    def get_all_repos(self, excluded_repos: list) -> list:
-        """
-        Get all repositories from a GitHub organization using the GitHub API
-
-        Args:
-            excluded_repos (list): A list of excluded repos to skip
-
-        Returns:
-            list: A list of remaining repos in the organisation
-        """
-        org_repos = []
-
-        # First API call
-        url = "/".join([self.api_url, "orgs", self.org_name, "repos"])
-        params = {"type": "public", "per_page": 100}
-        resp = get_request(url, headers=self.headers, params=params)
         for repo in resp.json():
             if repo["name"] not in excluded_repos:
                 org_repos.append(repo["name"])
 
-        # Paginate over results using the 'link' and rel['next'] parameters from
-        # the API response
-        # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
-        while "link" in resp.headers:
-            resp = get_request(
-                resp.links["next"]["url"], headers=self.headers, params=params
-            )
-            for repo in resp.json:
-                if repo["name"] not in excluded_repos:
-                    org_repos.append(repo["name"])
+    return org_repos
 
-        return org_repos
 
-    def get_contributors_from_repo(
-        self, repo: str, filepath=".all-contributorsrc"
-    ) -> list:
-        """Get contributors from a specific repository using the GitHub API
+def get_contributors_from_repo(
+    org_name: str, repo: str, github_token: str, filepath: str = ".all-contributorsrc"
+) -> list:
+    """Get contributors from a specific repository using the GitHub API
 
-        Args:
-            repo (str): The name of the repository to extract contributors from
-            filepath (str): The filepath to extract contributors from (default: .all-contributorsrc)
+    Args:
+        org_name: The name of the GitHub organisation
+        repo: The name of the repository to extract contributors from
+        github_token: GitHub token for authentication
+        filepath: The filepath to extract contributors from (default: .all-contributorsrc)
 
-        Returns:
-            list: A list of contributors from the repository, or an empty list if the file doesn't exist
-        """
-        url = "/".join(
-            [self.api_url, "repos", self.org_name, repo, "contents", filepath]
-        )
-        try:
-            resp = get_request(url, headers=self.headers, output="json")
-            resp = get_request(
-                resp["download_url"], headers=self.headers, output="json"
-            )
-            return resp["contributors"]
-        except requests.HTTPError as e:
-            if "404" in str(e):
-                print(f"Skipping {repo}: {filepath} not found")
-                return []
-            else:
-                raise
-
-    def run(self, merged_contributors: list) -> None:
-        """Run git flow to make a branch, commit a file, and open a PR"""
-        # Check if a PR exists
-        self.find_existing_pull_request()
-
-        # We want to work against the most up-to-date version of the target file
-        if self.pr_exists:
-            # If a PR exists, pull the file from there
-            file_contents = self.get_target_file_contents(self.head_branch)
+    Returns:
+        list: A list of contributors from the repository, or an empty list if the file doesn't exist
+    """
+    headers = _get_headers(github_token)
+    url = "/".join([API_URL, "repos", org_name, repo, "contents", filepath])
+    try:
+        resp = get_request(url, headers=headers, output="json")
+        resp = get_request(resp["download_url"], headers=headers, output="json")
+        return resp["contributors"]
+    except requests.HTTPError as e:
+        if "404" in str(e):
+            print(f"Skipping {repo}: {filepath} not found")
+            return []
         else:
-            # Otherwise, pull from the base of the repo
-            file_contents = self.get_target_file_contents(self.base_branch)
+            raise
 
-        file_contents = inject_config(file_contents, merged_contributors)
 
-        if not self.pr_exists:
-            # Create a branch to open a PR from
-            resp = self.get_ref(self.base_branch)
-            self.create_ref(self.head_branch, resp["object"]["sha"])
+def find_existing_pull_request(
+    org_name: str, repo_name: str, head_branch: str, github_token: str
+) -> tuple[bool, str, int | None]:
+    """Check if the bot already has an open Pull Request
 
-        # base64 encode the updated config file
-        encoded_file_contents = json.dumps(file_contents, indent=2).encode("utf-8")
-        base64_bytes = base64.b64encode(encoded_file_contents)
-        file_contents = base64_bytes.decode("utf-8")
+    Args:
+        org_name: The name of the GitHub organisation
+        repo_name: The name of the repository
+        head_branch: The head branch to search for
+        github_token: GitHub token for authentication
 
-        # Create a commit and open a pull request
-        self.create_commit(file_contents)
-        self.create_update_pull_request()
+    Returns:
+        tuple: (pr_exists, actual_head_branch, pr_number)
+            pr_exists: True if PR exists, False otherwise
+            actual_head_branch: The actual head branch name (may have random suffix)
+            pr_number: The PR number if exists, None otherwise
+    """
+    headers = _get_headers(github_token)
+    print("Finding Pull Requests previously opened to merge all contributors files")
+
+    url = "/".join([API_URL, "repos", org_name, repo_name, "pulls"])
+    params = {"state": "open", "sort": "created", "direction": "desc"}
+    resp = get_request(url, headers=headers, params=params, output="json")
+
+    # Expression to match the head ref
+    matches = jmespath.search("[*].head.label", resp)
+    indx, match = next(
+        (
+            (indx, match)
+            for (indx, match) in enumerate(matches)
+            if head_branch in match
+        ),
+        (None, None),
+    )
+
+    if (indx is None) and (match is None):
+        print("No relevant Pull Requests found. A new Pull Request will be opened.")
+        random_id = "".join(random.sample(string.ascii_letters, 4))
+        actual_head_branch = "/".join([head_branch, random_id])
+        return False, actual_head_branch, None
+    else:
+        print(
+            "Relevant Pull Request found. Will push new commits to this Pull Request."
+        )
+        actual_head_branch = match.split(":")[-1]
+        pr_number = resp[indx]["number"]
+        return True, actual_head_branch, pr_number
+
+
+def create_update_pull_request(
+    org_name: str,
+    repo_name: str,
+    base_branch: str,
+    head_branch: str,
+    pr_exists: bool,
+    pr_number: int | None,
+    github_token: str,
+) -> None:
+    """Create or update a Pull Request via the GitHub API
+
+    Args:
+        org_name: The name of the GitHub organisation
+        repo_name: The name of the repository
+        base_branch: The base branch for the PR
+        head_branch: The head branch for the PR
+        pr_exists: Whether the PR already exists
+        pr_number: The PR number if it exists
+        github_token: GitHub token for authentication
+    """
+    headers = _get_headers(github_token)
+    url = "/".join([API_URL, "repos", org_name, repo_name, "pulls"])
+    pr = {
+        "title": "Merging all-contributors across the org",
+        "body": "",  # FIXME: Add a descriptive PR body here
+        "base": base_branch,
+    }
+
+    if pr_exists:
+        print("Updating Pull Request...")
+        url = "/".join([url, str(pr_number)])
+        pr["state"] = "open"
+        resp = patch_request(
+            url,
+            headers=headers,
+            json=pr,
+            return_json=True,
+        )
+        print(f"Pull Request #{resp['number']} updated!")
+    else:
+        print("Creating Pull Request...")
+        pr["head"] = head_branch
+        resp = post_request(
+            url,
+            headers=headers,
+            json=pr,
+            return_json=True,
+        )
+        print(f"Pull Request #{resp['number']} created!")

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -94,7 +94,7 @@ def find_existing_pull_request(
     Returns:
         tuple: (pr_exists, actual_head_branch, pr_number)
             pr_exists: True if PR exists, False otherwise
-            actual_head_branch: The actual head branch name (may have random suffix)
+            head_branch: The head branch name (may have random suffix)
             pr_number: The PR number if exists, None otherwise
     """
     headers = _get_headers(github_token)

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -80,6 +80,24 @@ def get_contributors_from_repo(
             raise
 
 
+def fetch_all_contributors(org_name: str, github_token: str, repos: list) -> list:
+    """Fetch contributors from all repositories
+
+    Args:
+        org_name: GitHub organisation name
+        github_token: GitHub API token
+        repos: List of repository names to fetch from
+
+    Returns:
+        list: All contributors from all repositories
+    """
+    all_contributors = []
+    for repo in repos:
+        contributors = get_contributors_from_repo(org_name, repo, github_token)
+        all_contributors.extend(contributors)
+    return all_contributors
+
+
 def find_existing_pull_request(
     org_name: str, repo_name: str, head_branch: str, github_token: str
 ) -> tuple[bool, str, int | None]:

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -44,9 +44,7 @@ def get_all_repos(org_name: str, github_token: str, excluded_repos: list) -> lis
     # the API response
     # https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
     while "link" in resp.headers:
-        resp = get_request(
-            resp.links["next"]["url"], headers=headers, params=params
-        )
+        resp = get_request(resp.links["next"]["url"], headers=headers, params=params)
         for repo in resp.json():
             if repo["name"] not in excluded_repos:
                 org_repos.append(repo["name"])
@@ -109,11 +107,7 @@ def find_existing_pull_request(
     # Expression to match the head ref
     matches = jmespath.search("[*].head.label", resp)
     indx, match = next(
-        (
-            (indx, match)
-            for (indx, match) in enumerate(matches)
-            if head_branch in match
-        ),
+        ((indx, match) for (indx, match) in enumerate(matches) if head_branch in match),
         (None, None),
     )
 

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -5,7 +5,6 @@ import random
 import string
 import jmespath
 import requests
-from requests import put
 
 from .http_requests import get_request, patch_request, post_request
 from .inject import inject_config
@@ -53,55 +52,6 @@ class GitHubAPI:
         }
 
         self.api_url = "https://api.github.com"
-
-    def create_commit(
-        self,
-        contents: str,
-        commit_msg: str = "Merging all contributors info from across the org",
-    ):
-        """Create a commit over the GitHub API by creating or updating a file
-
-        Args:
-            contents (str): The content of the file to be updated, encoded in base64
-            commit_msg (str): A message describing the changes the commit applies.
-                (default: "Merging all contributors info from across the org")
-        """
-        print(f"Committing changes to file: {self.target_filepath}")
-        url = "/".join(
-            [
-                self.api_url,
-                "repos",
-                self.org_name,
-                self.target_repo_name,
-                "contents",
-                self.target_filepath,
-            ]
-        )
-        body = {
-            "message": commit_msg,
-            "content": contents,
-            "sha": self.sha,
-            "branch": self.head_branch,
-        }
-        put(url, json=body, headers=self.headers)
-
-    def create_ref(self, ref: str, sha: str):
-        """Create a new git reference (specifically, a branch) with GitHub's git
-        database API endpoint
-
-        Args:
-            ref (str): The reference or branch name to create
-            sha (str): The SHA of the parent commit to point the new reference to
-        """
-        print(f"Creating new branch: {ref}")
-        url = "/".join(
-            [self.api_url, "repos", self.org_name, self.target_repo_name, "git", "refs"]
-        )
-        body = {
-            "ref": f"refs/heads/{ref}",
-            "sha": sha,
-        }
-        post_request(url, headers=self.headers, json=body)
 
     def create_update_pull_request(self):
         """Create or update a Pull Request via the GitHub API"""
@@ -175,31 +125,6 @@ class GitHubAPI:
             self.pr_number = resp[indx]["number"]
             self.pr_exists = True
 
-    def get_ref(self, ref: str) -> dict:
-        """Get a git reference (specifically, a HEAD ref) using GitHub's git
-        database API endpoint
-
-        Args:
-            ref (str): The reference for which to return information for
-
-        Returns:
-            dict: The JSON payload response of the request
-        """
-        print(f"Pulling info for ref: {ref}")
-        url = "/".join(
-            [
-                self.api_url,
-                "repos",
-                self.org_name,
-                self.target_repo_name,
-                "git",
-                "ref",
-                "heads",
-                ref,
-            ]
-        )
-        return get_request(url, headers=self.headers, output="json")
-
     def get_all_repos(self, excluded_repos: list) -> list:
         """
         Get all repositories from a GitHub organization using the GitHub API
@@ -260,34 +185,6 @@ class GitHubAPI:
                 return []
             else:
                 raise
-
-    def get_target_file_contents(self, ref):
-        """Download the JSON-formatted contents of a target filepath in a target
-        repository inside a target GitHub org.
-
-        Args:
-            ref (str): The reference (branch) the file is stored on
-
-        Returns:
-            dict: The JSON formatted contents of the target filepath
-        """
-        url = "/".join(
-            [
-                self.api_url,
-                "repos",
-                self.org_name,
-                self.target_repo_name,
-                "contents",
-                self.target_filepath,
-            ]
-        )
-        resp = get_request(
-            url, headers=self.headers, params={"ref": ref}, output="json"
-        )
-        # Store the SHA for later use in create_commit
-        self.sha = resp["sha"]
-        resp = get_request(resp["download_url"], headers=self.headers, output="json")
-        return resp
 
     def run(self, merged_contributors: list) -> None:
         """Run git flow to make a branch, commit a file, and open a PR"""

--- a/all_all_contributors/inject.py
+++ b/all_all_contributors/inject.py
@@ -39,7 +39,9 @@ def load_config_file(
         }
 
 
-def write_config_file(config_path: str, file_contents: dict, target_filepath: str) -> None:
+def write_config_file(
+    config_path: str, file_contents: dict, target_filepath: str
+) -> None:
     """Write configuration file to disk
 
     Args:

--- a/all_all_contributors/inject.py
+++ b/all_all_contributors/inject.py
@@ -5,6 +5,54 @@ from typing import Any
 from .validate import validate_all_contributors_rc
 
 
+def load_config_file(
+    config_path: str, target_filepath: str, organisation: str, target_repo: str
+) -> dict:
+    """Load configuration file or create default structure
+
+    Args:
+        config_path: Full path to the config file
+        target_filepath: Relative path to the config file (for display)
+        organisation: GitHub organisation name
+        target_repo: Target repository name
+
+    Returns:
+        dict: Configuration dictionary
+    """
+    try:
+        with open(config_path, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"File {target_filepath} not found, creating with default structure")
+        return {
+            "files": ["README.md"],
+            "imageSize": 100,
+            "commit": False,
+            "commitConvention": "angular",
+            "contributors": [],
+            "contributorsPerLine": 7,
+            "skipCi": True,
+            "repoType": "github",
+            "repoHost": "https://github.com",
+            "projectName": target_repo,
+            "projectOwner": organisation,
+        }
+
+
+def write_config_file(config_path: str, file_contents: dict, target_filepath: str) -> None:
+    """Write configuration file to disk
+
+    Args:
+        config_path: Full path to the config file
+        file_contents: Configuration dictionary to write
+        target_filepath: Relative path to the config file (for display)
+    """
+    with open(config_path, "w") as f:
+        json.dump(file_contents, f, indent=2)
+        f.write("\n")  # Add trailing newline
+    print(f"Updated {target_filepath} with merged contributors")
+
+
 def inject_config(all_contributors_rc: dict[Any], contributors: list[Any]) -> dict[Any]:
     """Replace the 'contributors' field of an all contributors configuration
     JSON dict with a new list

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ class TestMain:
         mock_get_repos.return_value = ["repo1", "repo2"]
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1", "contributions": ["code"]}]
-        mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
+        mock_find_pr.return_value = (False, "merge-all-contributors/ABCD", None)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -108,7 +108,7 @@ class TestMain:
             github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
-            head_branch="merged-all-contributors",
+            head_branch="merge-all-contributors",
             working_dir="/test/repo",
         )
 
@@ -118,21 +118,21 @@ class TestMain:
         assert mock_get_contributors.call_count == 2
         mock_merge.assert_called_once()
         mock_find_pr.assert_called_once_with(
-            "test-org", "test-repo", "merged-all-contributors", "test-token"
+            "test-org", "test-repo", "merge-all-contributors", "test-token"
         )
         mock_checkout.assert_called_once_with(
-            "merged-all-contributors/ABCD", create=True, working_dir="/test/repo"
+            "merge-all-contributors/ABCD", create=True, working_dir="/test/repo"
         )
         mock_stage.assert_called_once_with("/test/repo")
         mock_commit.assert_called_once_with(
             "Merging all contributors info from across the org", "/test/repo"
         )
-        mock_push.assert_called_once_with("merged-all-contributors/ABCD", "/test/repo")
+        mock_push.assert_called_once_with("merge-all-contributors/ABCD", "/test/repo")
         mock_create_pr.assert_called_once_with(
             "test-org",
             "test-repo",
             "main",
-            "merged-all-contributors/ABCD",
+            "merge-all-contributors/ABCD",
             False,
             None,
             "test-token",
@@ -174,7 +174,7 @@ class TestMain:
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
-        mock_find_pr.return_value = (True, "merged-all-contributors/WXYZ", 42)
+        mock_find_pr.return_value = (True, "merge-all-contributors/WXYZ", 42)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -185,19 +185,19 @@ class TestMain:
             github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
-            head_branch="merged-all-contributors",
+            head_branch="merge-all-contributors",
             working_dir="/test/repo",
         )
 
         # Verify branch handling
         mock_checkout.assert_called_once_with(
-            "merged-all-contributors/WXYZ", create=False, working_dir="/test/repo"
+            "merge-all-contributors/WXYZ", create=False, working_dir="/test/repo"
         )
         mock_create_pr.assert_called_once_with(
             "test-org",
             "test-repo",
             "main",
-            "merged-all-contributors/WXYZ",
+            "merge-all-contributors/WXYZ",
             True,
             42,
             "test-token",
@@ -229,7 +229,7 @@ class TestMain:
             github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
-            head_branch="merged-all-contributors",
+            head_branch="merge-all-contributors",
             working_dir="/test/repo",
         )
 
@@ -271,7 +271,7 @@ class TestMain:
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
-        mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
+        mock_find_pr.return_value = (False, "merge-all-contributors/ABCD", None)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -286,7 +286,7 @@ class TestMain:
                 github_token="test-token",
                 target_filepath=".all-contributorsrc",
                 base_branch="main",
-                head_branch="merged-all-contributors",
+                head_branch="merge-all-contributors",
                 working_dir="/test/repo",
             )
 
@@ -320,7 +320,7 @@ class TestMain:
                             github_token="test-token",
                             target_filepath=".all-contributorsrc",
                             base_branch="main",
-                            head_branch="merged-all-contributors",
+                            head_branch="merge-all-contributors",
                             working_dir="/custom/working/dir",
                         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,11 @@ class TestGetGithubToken:
 
 class TestLoadExcludedRepos:
     @patch("all_all_contributors.cli.path.exists", return_value=True)
-    @patch("builtins.open", new_callable=mock_open, read_data="repo1\nrepo2\n# comment\nrepo3\n")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="repo1\nrepo2\n# comment\nrepo3\n",
+    )
     @patch.dict(os.environ, {"INPUT_IGNORE_FILE": "test.repoignore"})
     def test_loads_repos_from_file(self, mock_file, mock_exists):
         """Test that repos are loaded from file and comments are filtered"""
@@ -134,7 +138,9 @@ class TestMain:
         mock_find_pr.assert_called_once_with(
             "test-org", "test-repo", "merged-all-contributors", "test-token"
         )
-        mock_branch_exists.assert_called_once_with("merged-all-contributors/ABCD", "/test/repo")
+        mock_branch_exists.assert_called_once_with(
+            "merged-all-contributors/ABCD", "/test/repo"
+        )
         mock_checkout.assert_called_once_with(
             "merged-all-contributors/ABCD", create=True, working_dir="/test/repo"
         )
@@ -208,7 +214,9 @@ class TestMain:
         )
 
         # Verify branch handling
-        mock_branch_exists.assert_called_once_with("merged-all-contributors/WXYZ", "/test/repo")
+        mock_branch_exists.assert_called_once_with(
+            "merged-all-contributors/WXYZ", "/test/repo"
+        )
         mock_checkout.assert_called_once_with(
             "merged-all-contributors/WXYZ", create=False, working_dir="/test/repo"
         )
@@ -325,10 +333,16 @@ class TestMain:
 
         with patch("all_all_contributors.cli.load_excluded_repos") as mock_load:
             mock_load.return_value = set()
-            with patch("all_all_contributors.cli.github_api.get_all_repos") as mock_repos:
+            with patch(
+                "all_all_contributors.cli.github_api.get_all_repos"
+            ) as mock_repos:
                 mock_repos.return_value = []
-                with patch("all_all_contributors.cli.github_api.get_contributors_from_repo"):
-                    with patch("all_all_contributors.cli.merge_contributors") as mock_merge:
+                with patch(
+                    "all_all_contributors.cli.github_api.get_contributors_from_repo"
+                ):
+                    with patch(
+                        "all_all_contributors.cli.merge_contributors"
+                    ) as mock_merge:
                         mock_merge.return_value = []
 
                         cli.main(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,6 @@ class TestMain:
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -96,7 +95,6 @@ class TestMain:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_file,
@@ -114,7 +112,6 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1", "contributions": ["code"]}]
         mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
-        mock_branch_exists.return_value = (False, "merged-all-contributors/ABCD")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -137,7 +134,6 @@ class TestMain:
         mock_find_pr.assert_called_once_with(
             "test-org", "test-repo", "merged-all-contributors", "test-token"
         )
-        mock_branch_exists.assert_called_once_with("merged-all-contributors/ABCD", "/test/repo")
         mock_checkout.assert_called_once_with(
             "merged-all-contributors/ABCD", create=True, working_dir="/test/repo"
         )
@@ -163,9 +159,7 @@ class TestMain:
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
-    @patch("all_all_contributors.cli.git_operations.pull_latest")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -180,9 +174,7 @@ class TestMain:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
-        mock_pull,
         mock_inject,
         mock_file,
         mock_stage,
@@ -199,7 +191,6 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (True, "merged-all-contributors/WXYZ", 42)
-        mock_branch_exists.return_value = (True, "merged-all-contributors/WXYZ")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -214,11 +205,9 @@ class TestMain:
         )
 
         # Verify branch handling
-        mock_branch_exists.assert_called_once_with("merged-all-contributors/WXYZ", "/test/repo")
         mock_checkout.assert_called_once_with(
             "merged-all-contributors/WXYZ", create=False, working_dir="/test/repo"
         )
-        mock_pull.assert_called_once_with("/test/repo")
         mock_create_pr.assert_called_once_with(
             "test-org",
             "test-repo",
@@ -271,7 +260,6 @@ class TestMain:
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -286,7 +274,6 @@ class TestMain:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_stage,
@@ -303,7 +290,6 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
-        mock_branch_exists.return_value = (False, "merged-all-contributors/ABCD")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -361,7 +347,6 @@ class TestMain:
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -376,7 +361,6 @@ class TestMain:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_file,
@@ -394,7 +378,6 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         # No staged changes
         mock_has_changes.return_value = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,23 +29,7 @@ def unset_github_token(monkeypatch):
 class TestCli:
     def test_cli_missing_env(self, runner, unset_github_token):
         result = runner.invoke(app, ["organisation", "./target.txt"])
-        assert result.exit_code == 1
-        assert "Environment variable INPUT_GITHUB_TOKEN is not defined" in result.stdout
-
-
-class TestGetGithubToken:
-    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
-    def test_returns_token_when_set(self):
-        """Test that token is returned when environment variable is set"""
-        token = cli.get_github_token()
-        assert token == "test-token"
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_raises_exit_when_token_not_set(self):
-        """Test that Exit is raised when environment variable is not set"""
-        with pytest.raises(typer.Exit) as exc_info:
-            cli.get_github_token()
-        assert exc_info.value.exit_code == 1
+        assert result.exit_code == 2
 
 
 class TestLoadExcludedRepos:
@@ -73,6 +57,7 @@ class TestLoadExcludedRepos:
 
 
 class TestMain:
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -86,10 +71,8 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_main_workflow_with_new_branch(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -106,7 +89,6 @@ class TestMain:
     ):
         """Test main workflow when creating a new branch"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1", "repo2"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -119,6 +101,7 @@ class TestMain:
         cli.main(
             organisation="test-org",
             target_repo="test-repo",
+            github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
             head_branch="merged-all-contributors",
@@ -126,7 +109,6 @@ class TestMain:
         )
 
         # Verify workflow
-        mock_get_token.assert_called_once()
         mock_load_excluded.assert_called_once()
         mock_get_repos.assert_called_once_with("test-org", "test-token", set())
         assert mock_get_contributors.call_count == 2
@@ -152,6 +134,7 @@ class TestMain:
             "test-token",
         )
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -165,10 +148,8 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_main_workflow_with_existing_branch(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -185,7 +166,6 @@ class TestMain:
     ):
         """Test main workflow when branch already exists"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -198,6 +178,7 @@ class TestMain:
         cli.main(
             organisation="test-org",
             target_repo="test-repo",
+            github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
             head_branch="merged-all-contributors",
@@ -218,14 +199,13 @@ class TestMain:
             "test-token",
         )
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_main_exits_when_no_contributors(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -233,7 +213,6 @@ class TestMain:
     ):
         """Test that main returns early when no contributors found"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = []
@@ -243,6 +222,7 @@ class TestMain:
         result = cli.main(
             organisation="test-org",
             target_repo="test-repo",
+            github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
             head_branch="merged-all-contributors",
@@ -253,6 +233,7 @@ class TestMain:
         assert result is None
         mock_merge.assert_called_once_with([])
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -265,10 +246,8 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_main_creates_default_config_when_file_not_found(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -284,7 +263,6 @@ class TestMain:
     ):
         """Test that default config is created when file doesn't exist"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -301,6 +279,7 @@ class TestMain:
             cli.main(
                 organisation="test-org",
                 target_repo="test-repo",
+                github_token="test-token",
                 target_filepath=".all-contributorsrc",
                 base_branch="main",
                 head_branch="merged-all-contributors",
@@ -313,10 +292,9 @@ class TestMain:
         assert call_args[0]["projectOwner"] == "test-org"
         assert call_args[0]["contributors"] == []
 
-    @patch("all_all_contributors.cli.get_github_token")
-    def test_main_uses_custom_working_dir(self, mock_get_token):
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
+    def test_main_uses_custom_working_dir(self):
         """Test that custom working_dir parameter is used throughout"""
-        mock_get_token.return_value = "test-token"
 
         with patch("all_all_contributors.cli.load_excluded_repos") as mock_load:
             mock_load.return_value = set()
@@ -329,6 +307,7 @@ class TestMain:
                         cli.main(
                             organisation="test-org",
                             target_repo="test-repo",
+                            github_token="test-token",
                             target_filepath=".all-contributorsrc",
                             base_branch="main",
                             head_branch="merged-all-contributors",
@@ -339,6 +318,7 @@ class TestMain:
                         # (returns early due to no contributors, so just verify it accepts the parameter)
                         assert True
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -352,10 +332,8 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_main_returns_early_when_no_changes(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -372,7 +350,6 @@ class TestMain:
     ):
         """Test that main returns early when there are no changes"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -386,6 +363,7 @@ class TestMain:
         result = cli.main(
             organisation="test-org",
             target_repo="test-repo",
+            github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
             head_branch="test-branch",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,13 @@
+import json
+import os
+from unittest.mock import MagicMock, call, mock_open, patch
+
+import pytest
+import typer
 from pytest import fixture
 from typer.testing import CliRunner
 
+from all_all_contributors import cli
 from all_all_contributors.cli import app
 
 
@@ -24,3 +31,315 @@ class TestCli:
         result = runner.invoke(app, ["organisation", "./target.txt"])
         assert result.exit_code == 1
         assert "Environment variable INPUT_GITHUB_TOKEN is not defined" in result.stdout
+
+
+class TestGetGithubToken:
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
+    def test_returns_token_when_set(self):
+        """Test that token is returned when environment variable is set"""
+        token = cli.get_github_token()
+        assert token == "test-token"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_raises_exit_when_token_not_set(self):
+        """Test that Exit is raised when environment variable is not set"""
+        with pytest.raises(typer.Exit) as exc_info:
+            cli.get_github_token()
+        assert exc_info.value.exit_code == 1
+
+
+class TestLoadExcludedRepos:
+    @patch("all_all_contributors.cli.path.exists", return_value=True)
+    @patch("builtins.open", new_callable=mock_open, read_data="repo1\nrepo2\n# comment\nrepo3\n")
+    @patch.dict(os.environ, {"INPUT_IGNORE_FILE": "test.repoignore"})
+    def test_loads_repos_from_file(self, mock_file, mock_exists):
+        """Test that repos are loaded from file and comments are filtered"""
+        result = cli.load_excluded_repos()
+
+        assert "repo1\n" in result
+        assert "repo2\n" in result
+        assert "repo3\n" in result
+        # Comments should be filtered out
+        for item in result:
+            assert not item.startswith("#")
+        mock_file.assert_called_once_with("test.repoignore")
+
+    @patch("all_all_contributors.cli.path.exists", return_value=False)
+    @patch.dict(os.environ, {"INPUT_IGNORE_FILE": ".repoignore"})
+    def test_returns_empty_set_when_file_not_found(self, mock_exists):
+        """Test that empty set is returned when file doesn't exist"""
+        result = cli.load_excluded_repos()
+        assert result == set()
+
+
+class TestMain:
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_workflow_with_new_branch(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test main workflow when creating a new branch"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1", "repo2"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1", "contributions": ["code"]}]
+        mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
+        mock_branch_exists.return_value = False
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+
+        # Call main
+        cli.main(
+            organisation="test-org",
+            target_repo="test-repo",
+            target_filepath=".all-contributorsrc",
+            base_branch="main",
+            head_branch="merged-all-contributors",
+            working_dir="/test/repo",
+        )
+
+        # Verify workflow
+        mock_get_token.assert_called_once()
+        mock_load_excluded.assert_called_once()
+        mock_get_repos.assert_called_once_with("test-org", "test-token", set())
+        assert mock_get_contributors.call_count == 2
+        mock_merge.assert_called_once()
+        mock_find_pr.assert_called_once_with(
+            "test-org", "test-repo", "merged-all-contributors", "test-token"
+        )
+        mock_branch_exists.assert_called_once_with("merged-all-contributors/ABCD", "/test/repo")
+        mock_checkout.assert_called_once_with(
+            "merged-all-contributors/ABCD", create=True, working_dir="/test/repo"
+        )
+        mock_stage.assert_called_once_with("/test/repo")
+        mock_commit.assert_called_once_with(
+            "Merging all contributors info from across the org", "/test/repo"
+        )
+        mock_push.assert_called_once_with("merged-all-contributors/ABCD", "/test/repo")
+        mock_create_pr.assert_called_once_with(
+            "test-org",
+            "test-repo",
+            "main",
+            "merged-all-contributors/ABCD",
+            False,
+            None,
+            "test-token",
+        )
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.pull_latest")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_workflow_with_existing_branch(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_pull,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test main workflow when branch already exists"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (True, "merged-all-contributors/WXYZ", 42)
+        mock_branch_exists.return_value = True
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+
+        # Call main
+        cli.main(
+            organisation="test-org",
+            target_repo="test-repo",
+            target_filepath=".all-contributorsrc",
+            base_branch="main",
+            head_branch="merged-all-contributors",
+            working_dir="/test/repo",
+        )
+
+        # Verify branch handling
+        mock_branch_exists.assert_called_once_with("merged-all-contributors/WXYZ", "/test/repo")
+        mock_checkout.assert_called_once_with(
+            "merged-all-contributors/WXYZ", create=False, working_dir="/test/repo"
+        )
+        mock_pull.assert_called_once_with("/test/repo")
+        mock_create_pr.assert_called_once_with(
+            "test-org",
+            "test-repo",
+            "main",
+            "merged-all-contributors/WXYZ",
+            True,
+            42,
+            "test-token",
+        )
+
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_exits_when_no_contributors(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+    ):
+        """Test that main returns early when no contributors found"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = []
+        mock_merge.return_value = []
+
+        # Call main
+        result = cli.main(
+            organisation="test-org",
+            target_repo="test-repo",
+            target_filepath=".all-contributorsrc",
+            base_branch="main",
+            head_branch="merged-all-contributors",
+            working_dir="/test/repo",
+        )
+
+        # Should return None early
+        assert result is None
+        mock_merge.assert_called_once_with([])
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_creates_default_config_when_file_not_found(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test that default config is created when file doesn't exist"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
+        mock_branch_exists.return_value = False
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+
+        # Mock file operations - read raises FileNotFoundError, write succeeds
+        m = mock_open()
+        m.return_value.read.side_effect = FileNotFoundError
+
+        with patch("builtins.open", m):
+            cli.main(
+                organisation="test-org",
+                target_repo="test-repo",
+                target_filepath=".all-contributorsrc",
+                base_branch="main",
+                head_branch="merged-all-contributors",
+                working_dir="/test/repo",
+            )
+
+        # Verify inject_config was called with default config
+        call_args = mock_inject.call_args[0]
+        assert call_args[0]["projectName"] == "test-repo"
+        assert call_args[0]["projectOwner"] == "test-org"
+        assert call_args[0]["contributors"] == []
+
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_uses_custom_working_dir(self, mock_get_token):
+        """Test that custom working_dir parameter is used throughout"""
+        mock_get_token.return_value = "test-token"
+
+        with patch("all_all_contributors.cli.load_excluded_repos") as mock_load:
+            mock_load.return_value = set()
+            with patch("all_all_contributors.cli.github_api.get_all_repos") as mock_repos:
+                mock_repos.return_value = []
+                with patch("all_all_contributors.cli.github_api.get_contributors_from_repo"):
+                    with patch("all_all_contributors.cli.merge_contributors") as mock_merge:
+                        mock_merge.return_value = []
+
+                        cli.main(
+                            organisation="test-org",
+                            target_repo="test-repo",
+                            target_filepath=".all-contributorsrc",
+                            base_branch="main",
+                            head_branch="merged-all-contributors",
+                            working_dir="/custom/working/dir",
+                        )
+
+                        # Verify custom working dir would be used
+                        # (returns early due to no contributors, so just verify it accepts the parameter)
+                        assert True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,7 +123,7 @@ class TestMain:
         mock_checkout.assert_called_once_with(
             "merge-all-contributors/ABCD", create=True, working_dir="/test/repo"
         )
-        mock_stage.assert_called_once_with("/test/repo")
+        mock_stage.assert_called_once_with("/test/repo", ".all-contributorsrc")
         mock_commit.assert_called_once_with(
             "Merging all contributors info from across the org", "/test/repo"
         )
@@ -381,7 +381,7 @@ class TestMain:
         )
 
         # Verify early return - no commit, push, or PR creation
-        mock_has_changes.assert_called_once_with("/test/repo")
+        mock_has_changes.assert_called_once_with("/test/repo", ".all-contributorsrc")
         mock_commit.assert_not_called()
         mock_push.assert_not_called()
         mock_create_pr.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,7 +112,7 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1", "contributions": ["code"]}]
         mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
-        mock_branch_exists.return_value = False
+        mock_branch_exists.return_value = (False, "merged-all-contributors/ABCD")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
 
         # Call main
@@ -194,7 +194,7 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (True, "merged-all-contributors/WXYZ", 42)
-        mock_branch_exists.return_value = True
+        mock_branch_exists.return_value = (True, "merged-all-contributors/WXYZ")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
 
         # Call main

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,7 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
@@ -100,6 +101,7 @@ class TestMain:
         mock_inject,
         mock_file,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -114,6 +116,7 @@ class TestMain:
         mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
         mock_branch_exists.return_value = (False, "merged-all-contributors/ABCD")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
 
         # Call main
         cli.main(
@@ -156,6 +159,7 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
@@ -182,6 +186,7 @@ class TestMain:
         mock_inject,
         mock_file,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -196,6 +201,7 @@ class TestMain:
         mock_find_pr.return_value = (True, "merged-all-contributors/WXYZ", 42)
         mock_branch_exists.return_value = (True, "merged-all-contributors/WXYZ")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
 
         # Call main
         cli.main(
@@ -261,6 +267,7 @@ class TestMain:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
@@ -283,6 +290,7 @@ class TestMain:
         mock_checkout,
         mock_inject,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -295,8 +303,9 @@ class TestMain:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "merged-all-contributors/ABCD", None)
-        mock_branch_exists.return_value = False
+        mock_branch_exists.return_value = (False, "merged-all-contributors/ABCD")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
 
         # Mock file operations - read raises FileNotFoundError, write succeeds
         m = mock_open()
@@ -343,3 +352,66 @@ class TestMain:
                         # Verify custom working dir would be used
                         # (returns early due to no contributors, so just verify it accepts the parameter)
                         assert True
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_main_returns_early_when_no_changes(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_has_changes,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test that main returns early when there are no changes"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (False, "test-branch", None)
+        mock_branch_exists.return_value = (False, "test-branch")
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        # No staged changes
+        mock_has_changes.return_value = False
+
+        # Call main
+        result = cli.main(
+            organisation="test-org",
+            target_repo="test-repo",
+            target_filepath=".all-contributorsrc",
+            base_branch="main",
+            head_branch="test-branch",
+            working_dir="/test/repo",
+        )
+
+        # Verify early return - no commit, push, or PR creation
+        mock_has_changes.assert_called_once_with("/test/repo")
+        mock_commit.assert_not_called()
+        mock_push.assert_not_called()
+        mock_create_pr.assert_not_called()
+        assert result is None

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -12,9 +12,10 @@ class TestBranchExistsRemote:
         """Test that function returns True when branch exists on remote"""
         mock_run.return_value = MagicMock(stdout="abc123 refs/heads/test-branch\n")
 
-        result = git_operations.branch_exists_remote("test-branch", "/test/repo")
+        exists, branch_name = git_operations.branch_exists_remote("test-branch", "/test/repo")
 
-        assert result is True
+        assert exists is True
+        assert branch_name == "test-branch"
         mock_run.assert_called_once_with(
             ["git", "ls-remote", "--heads", "origin", "test-branch"],
             cwd="/test/repo",
@@ -28,9 +29,48 @@ class TestBranchExistsRemote:
         """Test that function returns False when branch doesn't exist on remote"""
         mock_run.return_value = MagicMock(stdout="")
 
-        result = git_operations.branch_exists_remote("test-branch", "/test/repo")
+        exists, branch_name = git_operations.branch_exists_remote("test-branch", "/test/repo")
 
-        assert result is False
+        assert exists is False
+        assert branch_name == "test-branch"
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_finds_existing_branch_with_prefix_pattern(self, mock_run):
+        """Test that function finds existing branch when checking with prefix pattern"""
+        # First call checks for prefix pattern, second is the fallback
+        mock_run.side_effect = [
+            MagicMock(stdout="def456\trefs/heads/merged-all-contributors/XyZw\n"),
+        ]
+
+        exists, branch_name = git_operations.branch_exists_remote(
+            "merged-all-contributors/aBcD", "/test/repo"
+        )
+
+        assert exists is True
+        assert branch_name == "merged-all-contributors/XyZw"
+        mock_run.assert_called_once_with(
+            ["git", "ls-remote", "--heads", "origin", "merged-all-contributors/*"],
+            cwd="/test/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_returns_false_when_no_prefix_match_exists(self, mock_run):
+        """Test that function returns False when no branch with prefix exists"""
+        # Both prefix pattern check and exact match return empty
+        mock_run.side_effect = [
+            MagicMock(stdout=""),  # prefix pattern check
+            MagicMock(stdout=""),  # exact match fallback
+        ]
+
+        exists, branch_name = git_operations.branch_exists_remote(
+            "merged-all-contributors/aBcD", "/test/repo"
+        )
+
+        assert exists is False
+        assert branch_name == "merged-all-contributors/aBcD"
 
 
 class TestCheckoutBranch:

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -6,6 +6,31 @@ import pytest
 from all_all_contributors import git_operations
 
 
+class TestConfigureSafeDirectory:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_configures_safe_directory(self, mock_run):
+        """Test that git config safe.directory is called with absolute path"""
+        git_operations.configure_safe_directory("/test/repo")
+
+        # Should be called with absolute path
+        mock_run.assert_called_once_with(
+            ["git", "config", "--global", "--add", "safe.directory", "/test/repo"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_subprocess_error_is_raised(self, mock_run):
+        """Test that subprocess errors are propagated"""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["git", "config"], stderr="error message"
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.configure_safe_directory("/test/repo")
+
+
 class TestCheckoutBranch:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_creates_new_branch(self, mock_run):

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -74,6 +74,7 @@ class TestCheckoutBranch:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_checks_out_remote_branch_when_local_fails(self, mock_run):
         """Test that remote branch is checked out when local checkout fails"""
+
         # First call is fetch (succeeds), second is checkout (fails), third is checkout --track (succeeds)
         def side_effect(*args, **kwargs):
             cmd = args[0]
@@ -81,7 +82,9 @@ class TestCheckoutBranch:
                 return MagicMock()
             elif cmd[0:2] == ["git", "checkout"] and len(cmd) == 3:
                 # Regular checkout fails
-                raise subprocess.CalledProcessError(1, cmd, stderr="pathspec did not match")
+                raise subprocess.CalledProcessError(
+                    1, cmd, stderr="pathspec did not match"
+                )
             elif cmd[0:3] == ["git", "checkout", "--track"]:
                 # Checkout with --track succeeds
                 return MagicMock()
@@ -126,6 +129,7 @@ class TestCheckoutBranch:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_continues_after_fetch_failure(self, mock_run):
         """Test that checkout continues even if fetch fails"""
+
         # First call is fetch (fails), second is checkout (succeeds)
         def side_effect(*args, **kwargs):
             cmd = args[0]

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -1,0 +1,134 @@
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from all_all_contributors import git_operations
+
+
+class TestBranchExistsRemote:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_returns_true_when_branch_exists(self, mock_run):
+        """Test that function returns True when branch exists on remote"""
+        mock_run.return_value = MagicMock(stdout="abc123 refs/heads/test-branch\n")
+
+        result = git_operations.branch_exists_remote("test-branch", "/test/repo")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["git", "ls-remote", "--heads", "origin", "test-branch"],
+            cwd="/test/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_returns_false_when_branch_does_not_exist(self, mock_run):
+        """Test that function returns False when branch doesn't exist on remote"""
+        mock_run.return_value = MagicMock(stdout="")
+
+        result = git_operations.branch_exists_remote("test-branch", "/test/repo")
+
+        assert result is False
+
+
+class TestCheckoutBranch:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_creates_new_branch(self, mock_run):
+        """Test that new branch is created when create=True"""
+        git_operations.checkout_branch("new-branch", create=True, working_dir="/test/repo")
+
+        mock_run.assert_called_once_with(
+            ["git", "checkout", "-b", "new-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_checks_out_existing_branch(self, mock_run):
+        """Test that existing branch is checked out when create=False"""
+        git_operations.checkout_branch(
+            "existing-branch", create=False, working_dir="/test/repo"
+        )
+
+        mock_run.assert_called_once_with(
+            ["git", "checkout", "existing-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestPullLatest:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_pulls_latest_changes(self, mock_run):
+        """Test that git pull is executed"""
+        git_operations.pull_latest("/test/repo")
+
+        mock_run.assert_called_once_with(
+            ["git", "pull"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestStageModifiedFiles:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_stages_modified_files_only(self, mock_run):
+        """Test that git add --update is executed"""
+        git_operations.stage_modified_files("/test/repo")
+
+        mock_run.assert_called_once_with(
+            ["git", "add", "--update"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestCreateCommit:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_creates_commit_with_message(self, mock_run):
+        """Test that commit is created with proper message"""
+        message = "Test commit message"
+        git_operations.create_commit(message, "/test/repo")
+
+        mock_run.assert_called_once_with(
+            ["git", "commit", "-m", message],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestPushBranch:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_pushes_branch_to_remote(self, mock_run):
+        """Test that branch is pushed to origin"""
+        git_operations.push_branch("test-branch", "/test/repo")
+
+        mock_run.assert_called_once_with(
+            ["git", "push", "origin", "test-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+class TestErrorHandling:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_subprocess_error_is_raised(self, mock_run):
+        """Test that subprocess errors are propagated"""
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "commit"])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.create_commit("Test", "/test/repo")

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -37,7 +37,9 @@ class TestCheckoutBranch:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_creates_new_branch(self, mock_run):
         """Test that new branch is created when create=True"""
-        git_operations.checkout_branch("new-branch", create=True, working_dir="/test/repo")
+        git_operations.checkout_branch(
+            "new-branch", create=True, working_dir="/test/repo"
+        )
 
         mock_run.assert_called_once_with(
             ["git", "checkout", "-b", "new-branch"],

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -48,19 +48,100 @@ class TestCheckoutBranch:
         )
 
     @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_checks_out_existing_branch(self, mock_run):
-        """Test that existing branch is checked out when create=False"""
+    def test_checks_out_existing_local_branch(self, mock_run):
+        """Test that existing local branch is checked out when create=False"""
         git_operations.checkout_branch(
             "existing-branch", create=False, working_dir="/test/repo"
         )
 
-        mock_run.assert_called_once_with(
+        # Should first fetch, then checkout
+        assert mock_run.call_count == 2
+        mock_run.assert_any_call(
+            ["git", "fetch", "origin", "existing-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        mock_run.assert_any_call(
             ["git", "checkout", "existing-branch"],
             cwd="/test/repo",
             check=True,
             capture_output=True,
             text=True,
         )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_checks_out_remote_branch_when_local_fails(self, mock_run):
+        """Test that remote branch is checked out when local checkout fails"""
+        # First call is fetch (succeeds), second is checkout (fails), third is checkout --track (succeeds)
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if cmd[0:2] == ["git", "fetch"]:
+                return MagicMock()
+            elif cmd[0:2] == ["git", "checkout"] and len(cmd) == 3:
+                # Regular checkout fails
+                raise subprocess.CalledProcessError(1, cmd, stderr="pathspec did not match")
+            elif cmd[0:3] == ["git", "checkout", "--track"]:
+                # Checkout with --track succeeds
+                return MagicMock()
+
+        mock_run.side_effect = side_effect
+
+        git_operations.checkout_branch(
+            "remote-branch", create=False, working_dir="/test/repo"
+        )
+
+        # Should fetch, try checkout, then checkout --track
+        assert mock_run.call_count == 3
+        calls = mock_run.call_args_list
+
+        # First call: fetch
+        assert calls[0] == call(
+            ["git", "fetch", "origin", "remote-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # Second call: checkout
+        assert calls[1] == call(
+            ["git", "checkout", "remote-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        # Third call: checkout --track
+        assert calls[2] == call(
+            ["git", "checkout", "--track", "origin/remote-branch"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_continues_after_fetch_failure(self, mock_run):
+        """Test that checkout continues even if fetch fails"""
+        # First call is fetch (fails), second is checkout (succeeds)
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if cmd[0:2] == ["git", "fetch"]:
+                raise subprocess.CalledProcessError(1, cmd, stderr="fetch failed")
+            elif cmd[0:2] == ["git", "checkout"]:
+                return MagicMock()
+
+        mock_run.side_effect = side_effect
+
+        git_operations.checkout_branch(
+            "local-branch", create=False, working_dir="/test/repo"
+        )
+
+        # Should attempt fetch and checkout
+        assert mock_run.call_count == 2
 
 
 class TestStageModifiedFiles:

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -133,6 +133,34 @@ class TestStageModifiedFiles:
         )
 
 
+class TestHasChanges:
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_returns_true_when_changes_exist(self, mock_run):
+        """Test that function returns True when there are changes"""
+        # git diff --quiet returns 1 when there are changes
+        mock_run.return_value = MagicMock(returncode=1)
+
+        result = git_operations.has_changes("/test/repo")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["git", "diff", "--quiet"],
+            cwd="/test/repo",
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_returns_false_when_no_changes_exist(self, mock_run):
+        """Test that function returns False when there are no changes"""
+        # git diff --quiet returns 0 when there are no changes
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = git_operations.has_changes("/test/repo")
+
+        assert result is False
+
+
 class TestCreateCommit:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_creates_commit_with_message(self, mock_run):

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -6,73 +6,6 @@ import pytest
 from all_all_contributors import git_operations
 
 
-class TestBranchExistsRemote:
-    @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_returns_true_when_branch_exists(self, mock_run):
-        """Test that function returns True when branch exists on remote"""
-        mock_run.return_value = MagicMock(stdout="abc123 refs/heads/test-branch\n")
-
-        exists, branch_name = git_operations.branch_exists_remote("test-branch", "/test/repo")
-
-        assert exists is True
-        assert branch_name == "test-branch"
-        mock_run.assert_called_once_with(
-            ["git", "ls-remote", "--heads", "origin", "test-branch"],
-            cwd="/test/repo",
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-    @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_returns_false_when_branch_does_not_exist(self, mock_run):
-        """Test that function returns False when branch doesn't exist on remote"""
-        mock_run.return_value = MagicMock(stdout="")
-
-        exists, branch_name = git_operations.branch_exists_remote("test-branch", "/test/repo")
-
-        assert exists is False
-        assert branch_name == "test-branch"
-
-    @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_finds_existing_branch_with_prefix_pattern(self, mock_run):
-        """Test that function finds existing branch when checking with prefix pattern"""
-        # First call checks for prefix pattern, second is the fallback
-        mock_run.side_effect = [
-            MagicMock(stdout="def456\trefs/heads/merged-all-contributors/XyZw\n"),
-        ]
-
-        exists, branch_name = git_operations.branch_exists_remote(
-            "merged-all-contributors/aBcD", "/test/repo"
-        )
-
-        assert exists is True
-        assert branch_name == "merged-all-contributors/XyZw"
-        mock_run.assert_called_once_with(
-            ["git", "ls-remote", "--heads", "origin", "merged-all-contributors/*"],
-            cwd="/test/repo",
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-    @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_returns_false_when_no_prefix_match_exists(self, mock_run):
-        """Test that function returns False when no branch with prefix exists"""
-        # Both prefix pattern check and exact match return empty
-        mock_run.side_effect = [
-            MagicMock(stdout=""),  # prefix pattern check
-            MagicMock(stdout=""),  # exact match fallback
-        ]
-
-        exists, branch_name = git_operations.branch_exists_remote(
-            "merged-all-contributors/aBcD", "/test/repo"
-        )
-
-        assert exists is False
-        assert branch_name == "merged-all-contributors/aBcD"
-
-
 class TestCheckoutBranch:
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_creates_new_branch(self, mock_run):
@@ -96,21 +29,6 @@ class TestCheckoutBranch:
 
         mock_run.assert_called_once_with(
             ["git", "checkout", "existing-branch"],
-            cwd="/test/repo",
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
-
-class TestPullLatest:
-    @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_pulls_latest_changes(self, mock_run):
-        """Test that git pull is executed"""
-        git_operations.pull_latest("/test/repo")
-
-        mock_run.assert_called_once_with(
-            ["git", "pull"],
             cwd="/test/repo",
             check=True,
             capture_output=True,

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,287 +1,246 @@
-import base64
-import json
-import unittest
-from unittest.mock import call, patch
+import random
+import string
+from unittest.mock import MagicMock, patch
 
-from all_all_contributors.github_api import GitHubAPI
-from all_all_contributors.yaml_parser import YamlParser
+import pytest
+import requests
 
-yaml = YamlParser()
+from all_all_contributors import github_api
 
 
-class TestGitHubAPI(unittest.TestCase):
-    def test_create_commit(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
+class TestGetHeaders:
+    def test_returns_correct_headers(self):
+        """Test that headers include correct accept and auth"""
+        token = "test-token"
+
+        headers = github_api._get_headers(token)
+
+        assert headers["Accept"] == "application/vnd.github.v3+json"
+        assert headers["Authorization"] == "token test-token"
+
+
+class TestGetAllRepos:
+    @patch("all_all_contributors.github_api.get_request")
+    def test_fetches_repos_and_filters_excluded(self, mock_get):
+        """Test that repos are fetched and excluded repos are filtered"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"name": "repo1"},
+            {"name": "repo2"},
+            {"name": "excluded-repo"},
+            {"name": "repo3"},
+        ]
+        mock_response.headers = {}  # No pagination
+        mock_get.return_value = mock_response
+
+        result = github_api.get_all_repos(
+            "test-org", "test-token", {"excluded-repo"}
         )
 
-        github.sha = "test_sha"
-        commit_msg = "This is a commit message"
-        contents = {"key1": "This is a test"}
+        assert result == ["repo1", "repo2", "repo3"]
+        mock_get.assert_called_once_with(
+            "https://api.github.com/orgs/test-org/repos",
+            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            params={"type": "public", "per_page": 100},
+        )
 
-        contents = json.dumps(contents, indent=2).encode("utf-8")
-        contents = base64.b64encode(contents)
-        contents = contents.decode("utf-8")
+    @patch("all_all_contributors.github_api.get_request")
+    def test_handles_pagination(self, mock_get):
+        """Test that pagination is handled correctly"""
+        # First page response
+        mock_response1 = MagicMock()
+        mock_response1.json.return_value = [
+            {"name": "repo1"},
+            {"name": "repo2"},
+        ]
+        mock_response1.headers = {"link": "next_url"}
+        mock_response1.links = {"next": {"url": "next_url"}}
 
-        body = {
-            "message": commit_msg,
-            "content": contents,
-            "sha": github.sha,
-            "branch": github.head_branch,
+        # Second page response
+        mock_response2 = MagicMock()
+        mock_response2.json.return_value = [
+            {"name": "repo3"},
+            {"name": "repo4"},
+        ]
+        mock_response2.headers = {}  # No more pages
+
+        mock_get.side_effect = [mock_response1, mock_response2]
+
+        result = github_api.get_all_repos("test-org", "test-token", set())
+
+        assert result == ["repo1", "repo2", "repo3", "repo4"]
+        assert mock_get.call_count == 2
+
+
+class TestGetContributorsFromRepo:
+    @patch("all_all_contributors.github_api.get_request")
+    def test_fetches_contributors_successfully(self, mock_get):
+        """Test that contributors are fetched from repo"""
+        # First call returns file metadata with download_url
+        mock_response1 = {
+            "download_url": "https://raw.githubusercontent.com/test-org/repo/.all-contributorsrc"
         }
-
-        with patch("all_all_contributors.github_api.put") as mock:
-            github.create_commit(
-                contents,
-                commit_msg=commit_msg,
-            )
-
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "contents",
-                        github.target_filepath,
-                    ]
-                ),
-                json=body,
-                headers=github.headers,
-            )
-
-    def test_create_update_pull_request(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
-        )
-        github.pr_exists = False
-
-        expected_pr = {
-            "title": "Merging all-contributors across the org",
-            "body": "",
-            "base": github.base_branch,
-            "head": github.head_branch,
+        # Second call returns actual file contents
+        mock_response2 = {
+            "contributors": [
+                {"login": "user1", "contributions": ["code"]},
+                {"login": "user2", "contributions": ["doc"]},
+            ]
         }
+        mock_get.side_effect = [mock_response1, mock_response2]
 
-        with patch("all_all_contributors.github_api.post_request") as mock:
-            github.create_update_pull_request()
+        result = github_api.get_contributors_from_repo(
+            "test-org", "test-repo", "test-token"
+        )
 
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "pulls",
-                    ]
-                ),
-                headers=github.headers,
-                json=expected_pr,
-                return_json=True,
+        assert len(result) == 2
+        assert result[0]["login"] == "user1"
+        assert result[1]["login"] == "user2"
+        assert mock_get.call_count == 2
+
+    @patch("all_all_contributors.github_api.get_request")
+    def test_returns_empty_list_on_404(self, mock_get):
+        """Test that 404 errors return empty list"""
+        mock_get.side_effect = requests.HTTPError("404 Client Error")
+
+        result = github_api.get_contributors_from_repo(
+            "test-org", "test-repo", "test-token"
+        )
+
+        assert result == []
+
+    @patch("all_all_contributors.github_api.get_request")
+    def test_raises_on_other_http_errors(self, mock_get):
+        """Test that non-404 HTTP errors are raised"""
+        mock_get.side_effect = requests.HTTPError("500 Server Error")
+
+        with pytest.raises(requests.HTTPError):
+            github_api.get_contributors_from_repo(
+                "test-org", "test-repo", "test-token"
             )
 
-    def test_create_ref(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
+    @patch("all_all_contributors.github_api.get_request")
+    def test_uses_custom_filepath(self, mock_get):
+        """Test that custom filepath is used in API call"""
+        mock_response1 = {"download_url": "https://example.com/custom.json"}
+        mock_response2 = {"contributors": []}
+        mock_get.side_effect = [mock_response1, mock_response2]
+
+        github_api.get_contributors_from_repo(
+            "test-org", "test-repo", "test-token", filepath="custom.json"
         )
-        test_ref = "test_ref"
-        test_sha = "test_sha"
 
-        test_body = {"ref": f"refs/heads/{test_ref}", "sha": test_sha}
+        # First call should use custom filepath
+        first_call_url = mock_get.call_args_list[0][0][0]
+        assert first_call_url.endswith("/custom.json")
 
-        with patch("all_all_contributors.github_api.post_request") as mock:
-            github.create_ref(test_ref, test_sha)
 
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "git",
-                        "refs",
-                    ]
-                ),
-                headers=github.headers,
-                json=test_body,
+class TestFindExistingPullRequest:
+    @patch("all_all_contributors.github_api.get_request")
+    def test_returns_false_when_no_pr_exists(self, mock_get):
+        """Test that function returns False and new branch name when no PR exists"""
+        mock_get.return_value = [
+            {"head": {"label": "test-org:some-other-branch"}, "number": 1}
+        ]
+
+        with patch.object(random, "sample", return_value=list("ABCD")):
+            pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
+                "test-org", "test-repo", "merged-all-contributors", "test-token"
             )
 
-    def test_find_existing_pull_request_no_matches(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
+        assert pr_exists is False
+        assert actual_head_branch == "merged-all-contributors/ABCD"
+        assert pr_number is None
+        mock_get.assert_called_once_with(
+            "https://api.github.com/repos/test-org/test-repo/pulls",
+            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            params={"state": "open", "sort": "created", "direction": "desc"},
+            output="json",
         )
 
-        mock_get = patch(
-            "all_all_contributors.github_api.get_request",
-            return_value=[
-                {
-                    "head": {
-                        "label": "some_branch",
-                    }
-                }
-            ],
+    @patch("all_all_contributors.github_api.get_request")
+    def test_returns_true_when_pr_exists(self, mock_get):
+        """Test that function returns True and existing branch details when PR exists"""
+        mock_get.return_value = [
+            {"head": {"label": "test-org:merged-all-contributors/WXYZ"}, "number": 42}
+        ]
+
+        pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
+            "test-org", "test-repo", "merged-all-contributors", "test-token"
         )
 
-        with mock_get as mock:
-            github.find_existing_pull_request()
+        assert pr_exists is True
+        assert actual_head_branch == "merged-all-contributors/WXYZ"
+        assert pr_number == 42
 
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "pulls",
-                    ]
-                ),
-                headers=github.headers,
-                params={"state": "open", "sort": "created", "direction": "desc"},
-                output="json",
-            )
-            self.assertFalse(github.pr_exists)
-            self.assertTrue(github.head_branch.startswith("merge-all-contributors"))
+    @patch("all_all_contributors.github_api.get_request")
+    def test_matches_partial_branch_name(self, mock_get):
+        """Test that branch name matching works with partial match"""
+        mock_get.return_value = [
+            {"head": {"label": "other-org:different-branch"}, "number": 1},
+            {"head": {"label": "test-org:merged-all-contributors/TEST"}, "number": 10},
+        ]
 
-    def test_find_existing_pull_request_match(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
+        pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
+            "test-org", "test-repo", "merged-all-contributors", "test-token"
         )
 
-        mock_get = patch(
-            "all_all_contributors.github_api.get_request",
-            return_value=[
-                {
-                    "head": {
-                        "label": "merge-all-contributors",
-                    },
-                    "number": 1,
-                }
-            ],
+        assert pr_exists is True
+        assert actual_head_branch == "merged-all-contributors/TEST"
+        assert pr_number == 10
+
+
+class TestCreateUpdatePullRequest:
+    @patch("all_all_contributors.github_api.post_request")
+    def test_creates_new_pull_request(self, mock_post):
+        """Test that new PR is created when pr_exists is False"""
+        mock_post.return_value = {"number": 123}
+
+        github_api.create_update_pull_request(
+            "test-org",
+            "test-repo",
+            "main",
+            "merged-all-contributors/ABCD",
+            pr_exists=False,
+            pr_number=None,
+            github_token="test-token",
         )
 
-        with mock_get as mock:
-            github.find_existing_pull_request()
-            print(github.head_branch)
-            print(github.pr_exists)
-
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "pulls",
-                    ]
-                ),
-                headers=github.headers,
-                params={"state": "open", "sort": "created", "direction": "desc"},
-                output="json",
-            )
-            self.assertTrue(github.pr_exists)
-            self.assertEqual(github.head_branch, "merge-all-contributors")
-            self.assertEqual(github.pr_number, 1)
-
-    def test_get_ref(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
-        )
-        test_ref = "test_ref"
-
-        mock_get = patch(
-            "all_all_contributors.github_api.get_request",
-            return_value={"object": {"sha": "sha"}},
+        mock_post.assert_called_once_with(
+            "https://api.github.com/repos/test-org/test-repo/pulls",
+            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            json={
+                "title": "Merging all-contributors across the org",
+                "body": "",
+                "base": "main",
+                "head": "merged-all-contributors/ABCD",
+            },
+            return_json=True,
         )
 
-        with mock_get as mock:
-            resp = github.get_ref(test_ref)
+    @patch("all_all_contributors.github_api.patch_request")
+    def test_updates_existing_pull_request(self, mock_patch):
+        """Test that existing PR is updated when pr_exists is True"""
+        mock_patch.return_value = {"number": 42}
 
-            self.assertEqual(mock.call_count, 1)
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "git",
-                        "ref",
-                        "heads",
-                        test_ref,
-                    ]
-                ),
-                headers=github.headers,
-                output="json",
-            )
-            self.assertDictEqual(resp, {"object": {"sha": "sha"}})
-
-    def test_update_existing_pr(self):
-        github = GitHubAPI(
-            "octocat",
-            "octocat",
-            "ThIs_Is_A_t0k3n",
-            ".all-contributorsrc",
-        )
-        github.pr_exists = True
-        github.pr_number = 1
-
-        expected_pr = {
-            "title": "Merging all-contributors across the org",
-            "body": "",
-            "base": github.base_branch,
-            "state": "open",
-        }
-
-        mock_patch = patch(
-            "all_all_contributors.github_api.patch_request", return_value={"number": 1}
+        github_api.create_update_pull_request(
+            "test-org",
+            "test-repo",
+            "main",
+            "merged-all-contributors/WXYZ",
+            pr_exists=True,
+            pr_number=42,
+            github_token="test-token",
         )
 
-        with mock_patch as mock:
-            github.create_update_pull_request()
-
-            mock.assert_called_with(
-                "/".join(
-                    [
-                        github.api_url,
-                        "repos",
-                        github.org_name,
-                        github.target_repo_name,
-                        "pulls",
-                        str(github.pr_number),
-                    ]
-                ),
-                headers=github.headers,
-                json=expected_pr,
-                return_json=True,
-            )
-            self.assertDictEqual(mock.return_value, {"number": 1})
-
-
-if __name__ == "__main__":
-    unittest.main()
+        mock_patch.assert_called_once_with(
+            "https://api.github.com/repos/test-org/test-repo/pulls/42",
+            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            json={
+                "title": "Merging all-contributors across the org",
+                "body": "",
+                "base": "main",
+                "state": "open",
+            },
+            return_json=True,
+        )

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -33,14 +33,15 @@ class TestGetAllRepos:
         mock_response.headers = {}  # No pagination
         mock_get.return_value = mock_response
 
-        result = github_api.get_all_repos(
-            "test-org", "test-token", {"excluded-repo"}
-        )
+        result = github_api.get_all_repos("test-org", "test-token", {"excluded-repo"})
 
         assert result == ["repo1", "repo2", "repo3"]
         mock_get.assert_called_once_with(
             "https://api.github.com/orgs/test-org/repos",
-            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token test-token",
+            },
             params={"type": "public", "per_page": 100},
         )
 
@@ -115,9 +116,7 @@ class TestGetContributorsFromRepo:
         mock_get.side_effect = requests.HTTPError("500 Server Error")
 
         with pytest.raises(requests.HTTPError):
-            github_api.get_contributors_from_repo(
-                "test-org", "test-repo", "test-token"
-            )
+            github_api.get_contributors_from_repo("test-org", "test-repo", "test-token")
 
     @patch("all_all_contributors.github_api.get_request")
     def test_uses_custom_filepath(self, mock_get):
@@ -144,8 +143,10 @@ class TestFindExistingPullRequest:
         ]
 
         with patch.object(random, "sample", return_value=list("ABCD")):
-            pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
-                "test-org", "test-repo", "merged-all-contributors", "test-token"
+            pr_exists, actual_head_branch, pr_number = (
+                github_api.find_existing_pull_request(
+                    "test-org", "test-repo", "merged-all-contributors", "test-token"
+                )
             )
 
         assert pr_exists is False
@@ -153,7 +154,10 @@ class TestFindExistingPullRequest:
         assert pr_number is None
         mock_get.assert_called_once_with(
             "https://api.github.com/repos/test-org/test-repo/pulls",
-            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token test-token",
+            },
             params={"state": "open", "sort": "created", "direction": "desc"},
             output="json",
         )
@@ -165,8 +169,10 @@ class TestFindExistingPullRequest:
             {"head": {"label": "test-org:merged-all-contributors/WXYZ"}, "number": 42}
         ]
 
-        pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
-            "test-org", "test-repo", "merged-all-contributors", "test-token"
+        pr_exists, actual_head_branch, pr_number = (
+            github_api.find_existing_pull_request(
+                "test-org", "test-repo", "merged-all-contributors", "test-token"
+            )
         )
 
         assert pr_exists is True
@@ -181,8 +187,10 @@ class TestFindExistingPullRequest:
             {"head": {"label": "test-org:merged-all-contributors/TEST"}, "number": 10},
         ]
 
-        pr_exists, actual_head_branch, pr_number = github_api.find_existing_pull_request(
-            "test-org", "test-repo", "merged-all-contributors", "test-token"
+        pr_exists, actual_head_branch, pr_number = (
+            github_api.find_existing_pull_request(
+                "test-org", "test-repo", "merged-all-contributors", "test-token"
+            )
         )
 
         assert pr_exists is True
@@ -208,7 +216,10 @@ class TestCreateUpdatePullRequest:
 
         mock_post.assert_called_once_with(
             "https://api.github.com/repos/test-org/test-repo/pulls",
-            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token test-token",
+            },
             json={
                 "title": "Merging all-contributors across the org",
                 "body": "",
@@ -235,7 +246,10 @@ class TestCreateUpdatePullRequest:
 
         mock_patch.assert_called_once_with(
             "https://api.github.com/repos/test-org/test-repo/pulls/42",
-            headers={"Accept": "application/vnd.github.v3+json", "Authorization": "token test-token"},
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token test-token",
+            },
             json={
                 "title": "Merging all-contributors across the org",
                 "body": "",

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -145,12 +145,12 @@ class TestFindExistingPullRequest:
         with patch.object(random, "sample", return_value=list("ABCD")):
             pr_exists, actual_head_branch, pr_number = (
                 github_api.find_existing_pull_request(
-                    "test-org", "test-repo", "merged-all-contributors", "test-token"
+                    "test-org", "test-repo", "merge-all-contributors", "test-token"
                 )
             )
 
         assert pr_exists is False
-        assert actual_head_branch == "merged-all-contributors/ABCD"
+        assert actual_head_branch == "merge-all-contributors/ABCD"
         assert pr_number is None
         mock_get.assert_called_once_with(
             "https://api.github.com/repos/test-org/test-repo/pulls",
@@ -166,17 +166,17 @@ class TestFindExistingPullRequest:
     def test_returns_true_when_pr_exists(self, mock_get):
         """Test that function returns True and existing branch details when PR exists"""
         mock_get.return_value = [
-            {"head": {"label": "test-org:merged-all-contributors/WXYZ"}, "number": 42}
+            {"head": {"label": "test-org:merge-all-contributors/WXYZ"}, "number": 42}
         ]
 
         pr_exists, actual_head_branch, pr_number = (
             github_api.find_existing_pull_request(
-                "test-org", "test-repo", "merged-all-contributors", "test-token"
+                "test-org", "test-repo", "merge-all-contributors", "test-token"
             )
         )
 
         assert pr_exists is True
-        assert actual_head_branch == "merged-all-contributors/WXYZ"
+        assert actual_head_branch == "merge-all-contributors/WXYZ"
         assert pr_number == 42
 
     @patch("all_all_contributors.github_api.get_request")
@@ -184,17 +184,17 @@ class TestFindExistingPullRequest:
         """Test that branch name matching works with partial match"""
         mock_get.return_value = [
             {"head": {"label": "other-org:different-branch"}, "number": 1},
-            {"head": {"label": "test-org:merged-all-contributors/TEST"}, "number": 10},
+            {"head": {"label": "test-org:merge-all-contributors/TEST"}, "number": 10},
         ]
 
         pr_exists, actual_head_branch, pr_number = (
             github_api.find_existing_pull_request(
-                "test-org", "test-repo", "merged-all-contributors", "test-token"
+                "test-org", "test-repo", "merge-all-contributors", "test-token"
             )
         )
 
         assert pr_exists is True
-        assert actual_head_branch == "merged-all-contributors/TEST"
+        assert actual_head_branch == "merge-all-contributors/TEST"
         assert pr_number == 10
 
 
@@ -208,7 +208,7 @@ class TestCreateUpdatePullRequest:
             "test-org",
             "test-repo",
             "main",
-            "merged-all-contributors/ABCD",
+            "merge-all-contributors/ABCD",
             pr_exists=False,
             pr_number=None,
             github_token="test-token",
@@ -224,7 +224,7 @@ class TestCreateUpdatePullRequest:
                 "title": "Merging all-contributors across the org",
                 "body": "",
                 "base": "main",
-                "head": "merged-all-contributors/ABCD",
+                "head": "merge-all-contributors/ABCD",
             },
             return_json=True,
         )
@@ -238,7 +238,7 @@ class TestCreateUpdatePullRequest:
             "test-org",
             "test-repo",
             "main",
-            "merged-all-contributors/WXYZ",
+            "merge-all-contributors/WXYZ",
             pr_exists=True,
             pr_number=42,
             github_token="test-token",

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -134,6 +134,50 @@ class TestGetContributorsFromRepo:
         assert first_call_url.endswith("/custom.json")
 
 
+class TestFetchAllContributors:
+    @patch("all_all_contributors.github_api.get_contributors_from_repo")
+    def test_fetches_contributors_from_multiple_repos(self, mock_get_contributors):
+        """Test that contributors are fetched from all repos and combined"""
+        mock_get_contributors.side_effect = [
+            [{"login": "user1", "contributions": ["code"]}],
+            [{"login": "user2", "contributions": ["doc"]}],
+            [{"login": "user3", "contributions": ["test"]}],
+        ]
+        repos = ["repo1", "repo2", "repo3"]
+
+        result = github_api.fetch_all_contributors("test-org", "test-token", repos)
+
+        assert len(result) == 3
+        assert result[0]["login"] == "user1"
+        assert result[1]["login"] == "user2"
+        assert result[2]["login"] == "user3"
+        assert mock_get_contributors.call_count == 3
+
+    @patch("all_all_contributors.github_api.get_contributors_from_repo")
+    def test_returns_empty_list_when_no_repos(self, mock_get_contributors):
+        """Test that empty list is returned when no repos provided"""
+        result = github_api.fetch_all_contributors("test-org", "test-token", [])
+
+        assert result == []
+        mock_get_contributors.assert_not_called()
+
+    @patch("all_all_contributors.github_api.get_contributors_from_repo")
+    def test_handles_repos_with_no_contributors(self, mock_get_contributors):
+        """Test that repos with no contributors don't break the flow"""
+        mock_get_contributors.side_effect = [
+            [{"login": "user1"}],
+            [],  # No contributors
+            [{"login": "user2"}],
+        ]
+        repos = ["repo1", "repo2", "repo3"]
+
+        result = github_api.fetch_all_contributors("test-org", "test-token", repos)
+
+        assert len(result) == 2
+        assert result[0]["login"] == "user1"
+        assert result[1]["login"] == "user2"
+
+
 class TestFindExistingPullRequest:
     @patch("all_all_contributors.github_api.get_request")
     def test_returns_false_when_no_pr_exists(self, mock_get):

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -1,8 +1,10 @@
 import json
+import os
+import tempfile
 
 from pytest import fixture, raises
 
-from all_all_contributors.inject import inject_config
+from all_all_contributors.inject import inject_config, load_config_file, write_config_file
 from all_all_contributors import inject as inject_mod
 
 
@@ -26,3 +28,85 @@ class TestInjectConfig:
         assert "contributors" in all_contributors_rc.keys()
         assert all_contributors_rc.get("contributors") == contributors
         assert all_contributors_rc.get("projectName") == "my-project"
+
+
+class TestLoadConfigFile:
+    def test_loads_existing_config_file(self):
+        """Test that existing config file is loaded correctly"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+            config_data = {
+                "contributors": [{"login": "user1"}],
+                "projectName": "test-project",
+            }
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+            result = load_config_file(
+                config_path, ".all-contributorsrc", "test-org", "test-repo"
+            )
+
+            assert result == config_data
+            assert result["projectName"] == "test-project"
+
+    def test_creates_default_config_when_file_not_found(self):
+        """Test that default config is returned when file doesn't exist"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+
+            result = load_config_file(
+                config_path, ".all-contributorsrc", "test-org", "test-repo"
+            )
+
+            assert isinstance(result, dict)
+            assert result["projectName"] == "test-repo"
+            assert result["projectOwner"] == "test-org"
+            assert result["contributors"] == []
+            assert result["files"] == ["README.md"]
+            assert result["imageSize"] == 100
+            assert result["repoType"] == "github"
+
+
+class TestWriteConfigFile:
+    def test_writes_config_file_with_proper_format(self):
+        """Test that config file is written with proper JSON formatting"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+            config_data = {
+                "contributors": [{"login": "user1"}],
+                "projectName": "test-project",
+            }
+
+            write_config_file(config_path, config_data, ".all-contributorsrc")
+
+            # Verify file was created
+            assert os.path.exists(config_path)
+
+            # Verify contents
+            with open(config_path, "r") as f:
+                content = f.read()
+                loaded = json.loads(content)
+
+            assert loaded == config_data
+            assert content.endswith("\n")  # Verify trailing newline
+
+    def test_overwrites_existing_file(self):
+        """Test that existing file is overwritten"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+
+            # Write initial content
+            initial_data = {"contributors": [], "projectName": "old-name"}
+            with open(config_path, "w") as f:
+                json.dump(initial_data, f)
+
+            # Overwrite with new content
+            new_data = {"contributors": [{"login": "user1"}], "projectName": "new-name"}
+            write_config_file(config_path, new_data, ".all-contributorsrc")
+
+            # Verify new content
+            with open(config_path, "r") as f:
+                loaded = json.load(f)
+
+            assert loaded == new_data
+            assert loaded["projectName"] == "new-name"

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -4,7 +4,11 @@ import tempfile
 
 from pytest import fixture, raises
 
-from all_all_contributors.inject import inject_config, load_config_file, write_config_file
+from all_all_contributors.inject import (
+    inject_config,
+    load_config_file,
+    write_config_file,
+)
 from all_all_contributors import inject as inject_mod
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Integration tests for error handling and workflow scenarios"""
+import os
 import subprocess
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -79,6 +80,7 @@ class TestGitHubAPIErrorHandling:
 class TestWorkflowIntegration:
     """Test workflow scenarios with multiple components"""
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -92,10 +94,8 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_workflow_handles_git_push_failure(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -112,7 +112,6 @@ class TestWorkflowIntegration:
     ):
         """Test that push failures propagate and don't create PR"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -129,6 +128,7 @@ class TestWorkflowIntegration:
             cli.main(
                 organisation="test-org",
                 target_repo="test-repo",
+                github_token="test-token",
                 target_filepath=".all-contributorsrc",
                 base_branch="main",
                 head_branch="test-branch",
@@ -138,6 +138,7 @@ class TestWorkflowIntegration:
         # PR should not be created after push failure
         mock_create_pr.assert_not_called()
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -151,10 +152,8 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_workflow_handles_commit_failure(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -171,7 +170,6 @@ class TestWorkflowIntegration:
     ):
         """Test that commit failures propagate correctly"""
         # Setup mocks
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -188,6 +186,7 @@ class TestWorkflowIntegration:
             cli.main(
                 organisation="test-org",
                 target_repo="test-repo",
+                github_token="test-token",
                 target_filepath=".all-contributorsrc",
                 base_branch="main",
                 head_branch="test-branch",
@@ -198,14 +197,13 @@ class TestWorkflowIntegration:
         mock_push.assert_not_called()
         mock_create_pr.assert_not_called()
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "bad-token"})
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_workflow_handles_github_auth_failure(
-        self, mock_get_token, mock_load_excluded, mock_get_repos
+        self, mock_load_excluded, mock_get_repos
     ):
         """Test that GitHub authentication failures are propagated"""
-        mock_get_token.return_value = "bad-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.side_effect = requests.HTTPError("401 Unauthorized")
 
@@ -213,12 +211,14 @@ class TestWorkflowIntegration:
             cli.main(
                 organisation="test-org",
                 target_repo="test-repo",
+                github_token="bad-token",
                 target_filepath=".all-contributorsrc",
                 base_branch="main",
                 head_branch="test-branch",
                 working_dir="/test/repo",
             )
 
+    @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
@@ -232,10 +232,8 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
-    @patch("all_all_contributors.cli.get_github_token")
     def test_workflow_completes_after_successful_push(
         self,
-        mock_get_token,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -252,7 +250,6 @@ class TestWorkflowIntegration:
     ):
         """Test that PR is created after successful push"""
         # Setup all mocks to succeed
-        mock_get_token.return_value = "test-token"
         mock_load_excluded.return_value = set()
         mock_get_repos.return_value = ["repo1"]
         mock_get_contributors.return_value = [{"login": "user1"}]
@@ -266,6 +263,7 @@ class TestWorkflowIntegration:
         cli.main(
             organisation="test-org",
             target_repo="test-repo",
+            github_token="test-token",
             target_filepath=".all-contributorsrc",
             base_branch="main",
             head_branch="test-branch",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,6 +90,7 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
@@ -114,6 +115,7 @@ class TestWorkflowIntegration:
         mock_inject,
         mock_file,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -128,6 +130,7 @@ class TestWorkflowIntegration:
         mock_find_pr.return_value = (False, "test-branch", None)
         mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
 
         # Make push fail
         mock_push.side_effect = subprocess.CalledProcessError(1, ["git", "push"])
@@ -149,6 +152,7 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
@@ -173,6 +177,7 @@ class TestWorkflowIntegration:
         mock_inject,
         mock_file,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -187,6 +192,7 @@ class TestWorkflowIntegration:
         mock_find_pr.return_value = (False, "test-branch", None)
         mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
 
         # Make commit fail (e.g., nothing to commit)
         mock_commit.side_effect = subprocess.CalledProcessError(1, ["git", "commit"])
@@ -230,6 +236,7 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.create_update_pull_request")
     @patch("all_all_contributors.cli.git_operations.push_branch")
     @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
@@ -254,6 +261,7 @@ class TestWorkflowIntegration:
         mock_inject,
         mock_file,
         mock_stage,
+        mock_has_changes,
         mock_commit,
         mock_push,
         mock_create_pr,
@@ -268,6 +276,7 @@ class TestWorkflowIntegration:
         mock_find_pr.return_value = (False, "test-branch", None)
         mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_has_changes.return_value = True
         mock_create_pr.return_value = None
 
         # Execute workflow

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Integration tests for error handling and workflow scenarios"""
+
 import subprocess
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -17,7 +18,9 @@ class TestGitErrorHandling:
         mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "checkout"])
 
         with pytest.raises(subprocess.CalledProcessError):
-            git_operations.checkout_branch("nonexistent-branch", create=False, working_dir="/test/repo")
+            git_operations.checkout_branch(
+                "nonexistent-branch", create=False, working_dir="/test/repo"
+            )
 
     @patch("all_all_contributors.git_operations.subprocess.run")
     def test_pull_fails_on_merge_conflict(self, mock_run):
@@ -79,8 +82,13 @@ class TestGitHubAPIErrorHandling:
 
         with pytest.raises(requests.HTTPError):
             github_api.create_update_pull_request(
-                "test-org", "test-repo", "main", "test-branch",
-                pr_exists=False, pr_number=None, github_token="token"
+                "test-org",
+                "test-repo",
+                "main",
+                "test-branch",
+                pr_exists=False,
+                pr_number=None,
+                github_token="token",
             )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Integration tests for error handling and workflow scenarios"""
+
 import os
 import subprocess
 from unittest.mock import MagicMock, mock_open, patch

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -126,7 +126,7 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = False
+        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
 
         # Make push fail
@@ -185,7 +185,7 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = False
+        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
 
         # Make commit fail (e.g., nothing to commit)
@@ -266,7 +266,7 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = False
+        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_create_pr.return_value = None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,14 +20,6 @@ class TestGitErrorHandling:
             git_operations.checkout_branch("nonexistent-branch", create=False, working_dir="/test/repo")
 
     @patch("all_all_contributors.git_operations.subprocess.run")
-    def test_pull_fails_on_merge_conflict(self, mock_run):
-        """Test that merge conflicts during pull raise CalledProcessError"""
-        mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "pull"])
-
-        with pytest.raises(subprocess.CalledProcessError):
-            git_operations.pull_latest("/test/repo")
-
-    @patch("all_all_contributors.git_operations.subprocess.run")
     def test_commit_fails_when_nothing_to_commit(self, mock_run):
         """Test that commit with no changes raises CalledProcessError"""
         mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "commit"])
@@ -95,7 +87,6 @@ class TestWorkflowIntegration:
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -110,7 +101,6 @@ class TestWorkflowIntegration:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_file,
@@ -128,7 +118,6 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -157,7 +146,6 @@ class TestWorkflowIntegration:
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -172,7 +160,6 @@ class TestWorkflowIntegration:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_file,
@@ -190,7 +177,6 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
 
@@ -241,7 +227,6 @@ class TestWorkflowIntegration:
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
-    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
     @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
     @patch("all_all_contributors.cli.merge_contributors")
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
@@ -256,7 +241,6 @@ class TestWorkflowIntegration:
         mock_get_contributors,
         mock_merge,
         mock_find_pr,
-        mock_branch_exists,
         mock_checkout,
         mock_inject,
         mock_file,
@@ -274,7 +258,6 @@ class TestWorkflowIntegration:
         mock_get_contributors.return_value = [{"login": "user1"}]
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
-        mock_branch_exists.return_value = (False, "test-branch")
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
         mock_has_changes.return_value = True
         mock_create_pr.return_value = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,287 @@
+"""Integration tests for error handling and workflow scenarios"""
+import subprocess
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+import requests
+
+from all_all_contributors import cli, git_operations, github_api
+
+
+class TestGitErrorHandling:
+    """Test that git command failures are handled properly"""
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_checkout_fails_on_invalid_branch(self, mock_run):
+        """Test that invalid branch checkout raises CalledProcessError"""
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "checkout"])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.checkout_branch("nonexistent-branch", create=False, working_dir="/test/repo")
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_pull_fails_on_merge_conflict(self, mock_run):
+        """Test that merge conflicts during pull raise CalledProcessError"""
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "pull"])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.pull_latest("/test/repo")
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_commit_fails_when_nothing_to_commit(self, mock_run):
+        """Test that commit with no changes raises CalledProcessError"""
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "commit"])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.create_commit("test message", "/test/repo")
+
+    @patch("all_all_contributors.git_operations.subprocess.run")
+    def test_push_fails_on_permission_denied(self, mock_run):
+        """Test that permission errors during push raise CalledProcessError"""
+        mock_run.side_effect = subprocess.CalledProcessError(128, ["git", "push"])
+
+        with pytest.raises(subprocess.CalledProcessError):
+            git_operations.push_branch("test-branch", "/test/repo")
+
+
+class TestGitHubAPIErrorHandling:
+    """Test that GitHub API failures are handled properly"""
+
+    @patch("all_all_contributors.github_api.get_request")
+    def test_get_repos_fails_on_auth_error(self, mock_get):
+        """Test that authentication errors during repo fetch raise HTTPError"""
+        mock_get.side_effect = requests.HTTPError("401 Unauthorized")
+
+        with pytest.raises(requests.HTTPError):
+            github_api.get_all_repos("test-org", "bad-token", set())
+
+    @patch("all_all_contributors.github_api.get_request")
+    def test_get_contributors_handles_404_gracefully(self, mock_get):
+        """Test that 404 errors return empty list instead of raising"""
+        mock_get.side_effect = requests.HTTPError("404 Not Found")
+
+        result = github_api.get_contributors_from_repo("test-org", "test-repo", "token")
+
+        assert result == []
+
+    @patch("all_all_contributors.github_api.get_request")
+    def test_get_contributors_raises_on_500_error(self, mock_get):
+        """Test that 5xx errors are not silently swallowed"""
+        mock_get.side_effect = requests.HTTPError("500 Internal Server Error")
+
+        with pytest.raises(requests.HTTPError):
+            github_api.get_contributors_from_repo("test-org", "test-repo", "token")
+
+    @patch("all_all_contributors.github_api.post_request")
+    def test_create_pr_fails_on_validation_error(self, mock_post):
+        """Test that PR creation validation errors raise HTTPError"""
+        mock_post.side_effect = requests.HTTPError("422 Unprocessable Entity")
+
+        with pytest.raises(requests.HTTPError):
+            github_api.create_update_pull_request(
+                "test-org", "test-repo", "main", "test-branch",
+                pr_exists=False, pr_number=None, github_token="token"
+            )
+
+
+class TestWorkflowIntegration:
+    """Test workflow scenarios with multiple components"""
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_workflow_handles_git_push_failure(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test that push failures propagate and don't create PR"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (False, "test-branch", None)
+        mock_branch_exists.return_value = False
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+
+        # Make push fail
+        mock_push.side_effect = subprocess.CalledProcessError(1, ["git", "push"])
+
+        # Workflow should fail at push
+        with pytest.raises(subprocess.CalledProcessError):
+            cli.main(
+                organisation="test-org",
+                target_repo="test-repo",
+                target_filepath=".all-contributorsrc",
+                base_branch="main",
+                head_branch="test-branch",
+                working_dir="/test/repo",
+            )
+
+        # PR should not be created after push failure
+        mock_create_pr.assert_not_called()
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_workflow_handles_commit_failure(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test that commit failures propagate correctly"""
+        # Setup mocks
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (False, "test-branch", None)
+        mock_branch_exists.return_value = False
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+
+        # Make commit fail (e.g., nothing to commit)
+        mock_commit.side_effect = subprocess.CalledProcessError(1, ["git", "commit"])
+
+        # Workflow should fail at commit
+        with pytest.raises(subprocess.CalledProcessError):
+            cli.main(
+                organisation="test-org",
+                target_repo="test-repo",
+                target_filepath=".all-contributorsrc",
+                base_branch="main",
+                head_branch="test-branch",
+                working_dir="/test/repo",
+            )
+
+        # Push and PR creation should not happen after commit failure
+        mock_push.assert_not_called()
+        mock_create_pr.assert_not_called()
+
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_workflow_handles_github_auth_failure(
+        self, mock_get_token, mock_load_excluded, mock_get_repos
+    ):
+        """Test that GitHub authentication failures are propagated"""
+        mock_get_token.return_value = "bad-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.side_effect = requests.HTTPError("401 Unauthorized")
+
+        with pytest.raises(requests.HTTPError):
+            cli.main(
+                organisation="test-org",
+                target_repo="test-repo",
+                target_filepath=".all-contributorsrc",
+                base_branch="main",
+                head_branch="test-branch",
+                working_dir="/test/repo",
+            )
+
+    @patch("all_all_contributors.cli.github_api.create_update_pull_request")
+    @patch("all_all_contributors.cli.git_operations.push_branch")
+    @patch("all_all_contributors.cli.git_operations.create_commit")
+    @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
+    @patch("all_all_contributors.cli.inject_config")
+    @patch("all_all_contributors.cli.git_operations.checkout_branch")
+    @patch("all_all_contributors.cli.git_operations.branch_exists_remote")
+    @patch("all_all_contributors.cli.github_api.find_existing_pull_request")
+    @patch("all_all_contributors.cli.merge_contributors")
+    @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
+    @patch("all_all_contributors.cli.github_api.get_all_repos")
+    @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.get_github_token")
+    def test_workflow_completes_after_successful_push(
+        self,
+        mock_get_token,
+        mock_load_excluded,
+        mock_get_repos,
+        mock_get_contributors,
+        mock_merge,
+        mock_find_pr,
+        mock_branch_exists,
+        mock_checkout,
+        mock_inject,
+        mock_file,
+        mock_stage,
+        mock_commit,
+        mock_push,
+        mock_create_pr,
+    ):
+        """Test that PR is created after successful push"""
+        # Setup all mocks to succeed
+        mock_get_token.return_value = "test-token"
+        mock_load_excluded.return_value = set()
+        mock_get_repos.return_value = ["repo1"]
+        mock_get_contributors.return_value = [{"login": "user1"}]
+        mock_merge.return_value = [{"login": "user1"}]
+        mock_find_pr.return_value = (False, "test-branch", None)
+        mock_branch_exists.return_value = False
+        mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_create_pr.return_value = None
+
+        # Execute workflow
+        cli.main(
+            organisation="test-org",
+            target_repo="test-repo",
+            target_filepath=".all-contributorsrc",
+            base_branch="main",
+            head_branch="test-branch",
+            working_dir="/test/repo",
+        )
+
+        # Verify push happened before PR creation
+        mock_push.assert_called_once_with("test-branch", "/test/repo")
+        mock_create_pr.assert_called_once_with(
+            "test-org", "test-repo", "main", "test-branch", False, None, "test-token"
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,8 +102,10 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.git_operations.configure_safe_directory")
     def test_workflow_handles_git_push_failure(
         self,
+        mock_configure_safe,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -160,8 +162,10 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.git_operations.configure_safe_directory")
     def test_workflow_handles_commit_failure(
         self,
+        mock_configure_safe,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,
@@ -208,8 +212,9 @@ class TestWorkflowIntegration:
     @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "bad-token"})
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.git_operations.configure_safe_directory")
     def test_workflow_handles_github_auth_failure(
-        self, mock_load_excluded, mock_get_repos
+        self, mock_configure_safe, mock_load_excluded, mock_get_repos
     ):
         """Test that GitHub authentication failures are propagated"""
         mock_load_excluded.return_value = set()
@@ -240,8 +245,10 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.github_api.get_contributors_from_repo")
     @patch("all_all_contributors.cli.github_api.get_all_repos")
     @patch("all_all_contributors.cli.load_excluded_repos")
+    @patch("all_all_contributors.cli.git_operations.configure_safe_directory")
     def test_workflow_completes_after_successful_push(
         self,
+        mock_configure_safe,
         mock_load_excluded,
         mock_get_repos,
         mock_get_contributors,


### PR DESCRIPTION
### Summary

Required for addressing #5 

The easiest method to regenerate the all-contributors table after updating the config file is to run the `all-contributors generate` CLI command. But because the original implementation of this action used the GitHub API to only pull the config file, the files that the command would update would need to be pulled as well. Ultimately, it'd be easier to have the repo checked out locally and then everything that is needed is present.

This PR is a refactor to use local git operations instead of the GitHub API. It's a big one, sorry!

### Changes

- git binary installed into the docker image (improved .dockerignore file to keep the image small as well)
- github api code reduced to just that required to:
  - list repos
  - pull config files from repos
  - open pull requests
- add funcs for local git flow commands
- workflow orchestration moved into cli.py with helper functions
- update tests
- update docs and helpstrings

### What should a reviewer concentrate on?

- [ ] Everything looks ok?

Here's a PR that was opened by this workflow: https://github.com/sgibson91-test-org/.github/pull/12
And the CI logs: https://github.com/sgibson91-test-org/.github/actions/runs/27910653182/job/82587087364