### PR TITLE
feat: ensure all-contributor tables get updated after config files are merged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-# Dockerfile copied from:
-# - https://github.com/sgibson91/bump-helm-deps-action/blob/main/Dockerfile
+# Multi-stage build: Stage 1 - Node.js builder for all-contributors CLI
+FROM node:22-slim AS node-builder
 
-# Use a Python slim image
+# Install all-contributors-cli globally
+RUN npm install -g all-contributors-cli
+
+# Multi-stage build: Stage 2 - Python runtime
 FROM python:3.14.6-slim
+
+# Copy Node.js runtime and all-contributors CLI from builder stage
+COPY --from=node-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+# Create symlink for all-contributors command
+RUN ln -s /usr/local/lib/node_modules/all-contributors-cli/dist/cli.js /usr/local/bin/all-contributors && \
+    chmod +x /usr/local/bin/all-contributors
 
 # Install git
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ jobs:
 | `head_branch` | A prefix to prepend to head branches when opening pull requests. Defaults to: `merge-all-contributors`. | no |
 | `working_dir` | Path to the checked-out git repository. Defaults to: `.` (current directory). | no |
 
+### What This Action Does
+
+When the action runs, it will:
+
+1. **Fetch Contributors**: Collect all `.all-contributorsrc` files from every repository in your organisation that using All Contributors
+2. **Merge Data**: Combine all contributors and their contributions into a single unified list
+3. **Regenerate Tables**: Automatically run `all-contributors generate` to update contributor tables in README files (based on the `files` array in `.all-contributorsrc`)
+4. **Create PR**: Open or update a pull request with:
+   - The merged `.all-contributorsrc` file
+   - Updated files with contributor tables (if generation succeeded)
+
+**Note:** The files that get updated with contributor tables are determined by the `files` array in your `.all-contributorsrc` configuration. Make sure this array includes all files where you want contributor tables to appear.
+
 ### Permissions
 
 This Action will need permission to read the contents of a files stored in repositories in an organisation, create a new branch, commit to that branch, and open a Pull Request.
@@ -134,6 +147,41 @@ If you cannot enable GitHub Actions to create pull requests (due to organization
    ```
 
 **Security Note:** Personal Access Tokens have broader permissions than `GITHUB_TOKEN`. Only use this approach if the GitHub Actions setting cannot be enabled, and ensure the PAT is stored securely as a repository secret.
+
+## Troubleshooting
+
+### Contributor Tables Not Generated
+
+If your PR only updates `.all-contributorsrc` but doesn't update files with tables:
+
+1. **Check the `files` array** in your `.all-contributorsrc`:
+   ```json
+   {
+     "files": ["README.md"],
+     "contributors": [...]
+   }
+   ```
+   The `files` array must list all files where you want contributor tables to appear.
+
+2. **Check PR description**: The PR body will indicate if table generation failed and provide the reason.
+
+3. **Manual generation**: If needed, you can run `all-contributors generate` manually and push to the PR.
+
+### Table Generation Failed
+
+If the PR indicates table generation failed, check:
+
+- The `files` in your config actually exist in the repository
+- The table files have the proper comment markers for all-contributors
+- Check the action logs for specific error messages from the `all-contributors` CLI
+
+### Empty Contributor List
+
+If the merged `.all-contributorsrc` has no contributors:
+
+- Ensure your organization's repositories have `.all-contributorsrc` files
+- Check that the GitHub token has permission to read from all repositories in the organization
+- Review the action logs for any "404" or "permission denied" messages
 
 ## Contributors ✨
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,8 +1,9 @@
 name: "all-all-contributors"
 description: >-
   A GitHub Action that merges all-contributors files (https://allcontributors.org)
-  from repos within an organisation and opens a Pull Request to a chosen repo to
-  host the full list of contributors in.
+  from repos within an organisation, automatically regenerates contributor tables in
+  files, and opens a Pull Request to a chosen repo with the complete merged
+  contributor data and updated tables.
 
   IMPORTANT: This action requires the repository to be checked out first using
   actions/checkout@v4. Git authentication is handled automatically by actions/checkout

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import typer
 
-from . import git_operations, github_api
+from . import contributor_table, git_operations, github_api
 from .inject import inject_config, load_config_file, write_config_file
 from .merge import merge_contributors
 
@@ -115,16 +115,17 @@ def main(
     file_contents = inject_config(file_contents, merged_contributors)
     write_config_file(config_path, file_contents, target_filepath)
 
+    # Generate contributor tables
+    updated_files = contributor_table.generate_contributor_tables(working_dir)
+
     # Check if there are any changes to commit
-    if not git_operations.has_changes(working_dir, target_filepath):
+    if not git_operations.has_changes(working_dir):
         print("No changes to commit - contributors list is already up to date")
         return
 
-    # Stage the specific file we modified
-    git_operations.stage_modified_files(working_dir, target_filepath)
+    # Stage all modified files (config + any README files that were updated)
+    git_operations.stage_modified_files(working_dir)
 
-    # Create commit
-    commit_message = "Merging all contributors info from across the org"
     git_operations.create_commit(commit_message, working_dir)
 
     # Push branch to remote

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -149,6 +149,8 @@ def main(
         pr_exists,
         pr_number,
         github_token,
+        config_filepath=target_filepath,
+        updated_files=updated_files,
     )
 
 

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -134,7 +134,9 @@ def main(
             + "\n".join(f"- {f}" for f in updated_files)
         )
     else:
-        commit_message = f"Merge all-contributors from across the org\n\nUpdated: {target_filepath}"
+        commit_message = (
+            f"Merge all-contributors from across the org\n\nUpdated: {target_filepath}"
+        )
     git_operations.create_commit(commit_message, working_dir)
 
     # Push branch to remote

--- a/all_all_contributors/cli.py
+++ b/all_all_contributors/cli.py
@@ -126,6 +126,15 @@ def main(
     # Stage all modified files (config + any README files that were updated)
     git_operations.stage_modified_files(working_dir)
 
+    # Create commit with descriptive message
+    if updated_files:
+        commit_message = (
+            f"Merge all-contributors from across the org\n\n"
+            f"Updated files:\n- {target_filepath}\n"
+            + "\n".join(f"- {f}" for f in updated_files)
+        )
+    else:
+        commit_message = f"Merge all-contributors from across the org\n\nUpdated: {target_filepath}"
     git_operations.create_commit(commit_message, working_dir)
 
     # Push branch to remote

--- a/all_all_contributors/contributor_table.py
+++ b/all_all_contributors/contributor_table.py
@@ -1,0 +1,78 @@
+"""Generate contributor tables using the all-contributors CLI."""
+
+import json
+import os
+import subprocess
+from typing import Optional
+
+
+def get_files_to_update(config_path: str) -> list[str]:
+    """Get list of files that should be updated based on .all-contributorsrc config.
+
+    Args:
+        config_path: Path to .all-contributorsrc file
+
+    Returns:
+        List of file paths from the config's 'files' array
+    """
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        return config.get("files", [])
+    except FileNotFoundError:
+        print(f"Config file not found: {config_path}")
+        return []
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse config file: {e}")
+        return []
+    except Exception as e:
+        print(f"Error reading config file: {e}")
+        return []
+
+
+def generate_contributor_tables(working_dir: str) -> Optional[list[str]]:
+    """Run all-contributors generate to update contributor tables in README files.
+
+    Args:
+        working_dir: Repository working directory containing .all-contributorsrc
+
+    Returns:
+        List of file paths that were updated (relative to working_dir),
+        or None if generation failed
+    """
+    print("Generating contributor tables...")
+
+    # Get list of files that should be updated
+    config_path = os.path.join(working_dir, ".all-contributorsrc")
+    files_to_update = get_files_to_update(config_path)
+
+    if not files_to_update:
+        print("No files specified in .all-contributorsrc, skipping table generation")
+        return None
+
+    # Run all-contributors generate
+    try:
+        result = subprocess.run(
+            ["all-contributors", "generate"],
+            cwd=working_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("Contributor tables generated successfully")
+        if result.stdout:
+            print(result.stdout)
+        return files_to_update
+    except FileNotFoundError:
+        print("Error: all-contributors CLI not found")
+        print("Table generation will be skipped")
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"Error running all-contributors generate: {e}")
+        if e.stderr:
+            print(f"Error output: {e.stderr}")
+        print("Table generation failed, continuing without tables")
+        return None
+    except Exception as e:
+        print(f"Unexpected error during table generation: {e}")
+        return None

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -188,7 +188,9 @@ def create_update_pull_request(
             body_parts.append(f"- `{file}`")
     else:
         body_parts.append("")
-        body_parts.append("**Note:** Contributor table generation was skipped or failed. The `.all-contributorsrc` file has been updated, but you may need to run `all-contributors generate` manually to update README files.")
+        body_parts.append(
+            "**Note:** Contributor table generation was skipped or failed. The `.all-contributorsrc` file has been updated, but you may need to run `all-contributors generate` manually to update README files."
+        )
 
     pr_body = "\n".join(body_parts)
 

--- a/all_all_contributors/github_api.py
+++ b/all_all_contributors/github_api.py
@@ -151,6 +151,8 @@ def create_update_pull_request(
     pr_exists: bool,
     pr_number: int | None,
     github_token: str,
+    config_filepath: str = ".all-contributorsrc",
+    updated_files: list[str] | None = None,
 ) -> None:
     """Create or update a Pull Request via the GitHub API
 
@@ -162,12 +164,37 @@ def create_update_pull_request(
         pr_exists: Whether the PR already exists
         pr_number: The PR number if it exists
         github_token: GitHub token for authentication
+        config_filepath: Path to the config file that was updated
+        updated_files: List of files updated by all-contributors generate, or None if skipped
     """
     headers = _get_headers(github_token)
     url = "/".join([API_URL, "repos", org_name, repo_name, "pulls"])
+
+    # Build PR body
+    body_parts = [
+        "## Summary",
+        "",
+        "This PR merges all-contributors data from across the organization.",
+        "",
+        "## Files Updated",
+        "",
+        f"- `{config_filepath}` (contributor data)",
+    ]
+
+    if updated_files:
+        body_parts.append("")
+        body_parts.append("**Contributor tables generated:**")
+        for file in updated_files:
+            body_parts.append(f"- `{file}`")
+    else:
+        body_parts.append("")
+        body_parts.append("**Note:** Contributor table generation was skipped or failed. The `.all-contributorsrc` file has been updated, but you may need to run `all-contributors generate` manually to update README files.")
+
+    pr_body = "\n".join(body_parts)
+
     pr = {
         "title": "Merging all-contributors across the org",
-        "body": "",  # FIXME: Add a descriptive PR body here
+        "body": pr_body,
         "base": base_branch,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,8 @@ class TestMain:
             False,
             None,
             "test-token",
+            config_filepath=".all-contributorsrc",
+            updated_files=None,
         )
 
     @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})
@@ -203,6 +205,8 @@ class TestMain:
             True,
             42,
             "test-token",
+            config_filepath=".all-contributorsrc",
+            updated_files=None,
         )
 
     @patch.dict(os.environ, {"INPUT_GITHUB_TOKEN": "test-token"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,7 @@ class TestMain:
     @patch("all_all_contributors.cli.git_operations.create_commit")
     @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("all_all_contributors.cli.contributor_table.generate_contributor_tables")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
@@ -85,6 +86,7 @@ class TestMain:
         mock_checkout,
         mock_inject,
         mock_file,
+        mock_generate_tables,
         mock_stage,
         mock_has_changes,
         mock_commit,
@@ -99,6 +101,7 @@ class TestMain:
         mock_merge.return_value = [{"login": "user1", "contributions": ["code"]}]
         mock_find_pr.return_value = (False, "merge-all-contributors/ABCD", None)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_generate_tables.return_value = None
         mock_has_changes.return_value = True
 
         # Call main
@@ -123,10 +126,9 @@ class TestMain:
         mock_checkout.assert_called_once_with(
             "merge-all-contributors/ABCD", create=True, working_dir="/test/repo"
         )
-        mock_stage.assert_called_once_with("/test/repo", ".all-contributorsrc")
-        mock_commit.assert_called_once_with(
-            "Merging all contributors info from across the org", "/test/repo"
-        )
+        mock_generate_tables.assert_called_once_with("/test/repo")
+        mock_stage.assert_called_once_with("/test/repo")
+        mock_commit.assert_called_once()
         mock_push.assert_called_once_with("merge-all-contributors/ABCD", "/test/repo")
         mock_create_pr.assert_called_once_with(
             "test-org",
@@ -334,6 +336,7 @@ class TestMain:
     @patch("all_all_contributors.cli.git_operations.create_commit")
     @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("all_all_contributors.cli.contributor_table.generate_contributor_tables")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
@@ -352,6 +355,7 @@ class TestMain:
         mock_checkout,
         mock_inject,
         mock_file,
+        mock_generate_tables,
         mock_stage,
         mock_has_changes,
         mock_commit,
@@ -366,6 +370,7 @@ class TestMain:
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_generate_tables.return_value = None
         # No staged changes
         mock_has_changes.return_value = False
 
@@ -381,7 +386,7 @@ class TestMain:
         )
 
         # Verify early return - no commit, push, or PR creation
-        mock_has_changes.assert_called_once_with("/test/repo", ".all-contributorsrc")
+        mock_has_changes.assert_called_once_with("/test/repo")
         mock_commit.assert_not_called()
         mock_push.assert_not_called()
         mock_create_pr.assert_not_called()

--- a/tests/test_contributor_table.py
+++ b/tests/test_contributor_table.py
@@ -1,0 +1,132 @@
+import json
+import os
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from all_all_contributors import contributor_table
+
+
+class TestGetFilesToUpdate:
+    def test_returns_files_from_config(self):
+        """Test that files array is extracted from config"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+            config_data = {
+                "contributors": [],
+                "files": ["README.md", "docs/CONTRIBUTORS.md"],
+            }
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+            result = contributor_table.get_files_to_update(config_path)
+
+            assert result == ["README.md", "docs/CONTRIBUTORS.md"]
+
+    def test_returns_empty_list_when_no_files_key(self):
+        """Test that empty list is returned when 'files' key is missing"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+            config_data = {"contributors": []}
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+            result = contributor_table.get_files_to_update(config_path)
+
+            assert result == []
+
+    def test_returns_empty_list_when_file_not_found(self):
+        """Test that empty list is returned when config file doesn't exist"""
+        result = contributor_table.get_files_to_update("/nonexistent/path/.all-contributorsrc")
+
+        assert result == []
+
+    def test_handles_invalid_json(self):
+        """Test that invalid JSON is handled gracefully"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, ".all-contributorsrc")
+            with open(config_path, "w") as f:
+                f.write("not valid json{")
+
+            result = contributor_table.get_files_to_update(config_path)
+
+            assert result == []
+
+
+class TestGenerateContributorTables:
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_generates_tables_successfully(self, mock_get_files, mock_run):
+        """Test successful table generation"""
+        mock_get_files.return_value = ["README.md"]
+        mock_run.return_value = MagicMock(stdout="Generated contributor table", stderr="")
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result == ["README.md"]
+        mock_run.assert_called_once_with(
+            ["all-contributors", "generate"],
+            cwd="/test/repo",
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_returns_none_when_no_files_in_config(self, mock_get_files, mock_run):
+        """Test that None is returned when no files are specified"""
+        mock_get_files.return_value = []
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result is None
+        mock_run.assert_not_called()
+
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_handles_cli_not_found(self, mock_get_files, mock_run):
+        """Test handling when all-contributors CLI is not installed"""
+        mock_get_files.return_value = ["README.md"]
+        mock_run.side_effect = FileNotFoundError("all-contributors not found")
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result is None
+
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_handles_generation_failure(self, mock_get_files, mock_run):
+        """Test handling when all-contributors generate fails"""
+        mock_get_files.return_value = ["README.md"]
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["all-contributors", "generate"], stderr="Generation failed"
+        )
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result is None
+
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_handles_multiple_files(self, mock_get_files, mock_run):
+        """Test handling multiple files to update"""
+        mock_get_files.return_value = ["README.md", "docs/CONTRIBUTORS.md", "CHANGELOG.md"]
+        mock_run.return_value = MagicMock(stdout="", stderr="")
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result == ["README.md", "docs/CONTRIBUTORS.md", "CHANGELOG.md"]
+
+    @patch("all_all_contributors.contributor_table.subprocess.run")
+    @patch("all_all_contributors.contributor_table.get_files_to_update")
+    def test_handles_unexpected_exception(self, mock_get_files, mock_run):
+        """Test handling of unexpected exceptions"""
+        mock_get_files.return_value = ["README.md"]
+        mock_run.side_effect = Exception("Unexpected error")
+
+        result = contributor_table.generate_contributor_tables("/test/repo")
+
+        assert result is None

--- a/tests/test_contributor_table.py
+++ b/tests/test_contributor_table.py
@@ -39,7 +39,9 @@ class TestGetFilesToUpdate:
 
     def test_returns_empty_list_when_file_not_found(self):
         """Test that empty list is returned when config file doesn't exist"""
-        result = contributor_table.get_files_to_update("/nonexistent/path/.all-contributorsrc")
+        result = contributor_table.get_files_to_update(
+            "/nonexistent/path/.all-contributorsrc"
+        )
 
         assert result == []
 
@@ -61,7 +63,9 @@ class TestGenerateContributorTables:
     def test_generates_tables_successfully(self, mock_get_files, mock_run):
         """Test successful table generation"""
         mock_get_files.return_value = ["README.md"]
-        mock_run.return_value = MagicMock(stdout="Generated contributor table", stderr="")
+        mock_run.return_value = MagicMock(
+            stdout="Generated contributor table", stderr=""
+        )
 
         result = contributor_table.generate_contributor_tables("/test/repo")
 
@@ -113,7 +117,11 @@ class TestGenerateContributorTables:
     @patch("all_all_contributors.contributor_table.get_files_to_update")
     def test_handles_multiple_files(self, mock_get_files, mock_run):
         """Test handling multiple files to update"""
-        mock_get_files.return_value = ["README.md", "docs/CONTRIBUTORS.md", "CHANGELOG.md"]
+        mock_get_files.return_value = [
+            "README.md",
+            "docs/CONTRIBUTORS.md",
+            "CHANGELOG.md",
+        ]
         mock_run.return_value = MagicMock(stdout="", stderr="")
 
         result = contributor_table.generate_contributor_tables("/test/repo")

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -258,20 +258,24 @@ class TestCreateUpdatePullRequest:
             github_token="test-token",
         )
 
-        mock_post.assert_called_once_with(
-            "https://api.github.com/repos/test-org/test-repo/pulls",
-            headers={
-                "Accept": "application/vnd.github.v3+json",
-                "Authorization": "token test-token",
-            },
-            json={
-                "title": "Merging all-contributors across the org",
-                "body": "",
-                "base": "main",
-                "head": "merge-all-contributors/ABCD",
-            },
-            return_json=True,
-        )
+        # Verify the call
+        assert mock_post.call_count == 1
+        call_args = mock_post.call_args
+
+        # Check URL and headers
+        assert call_args[0][0] == "https://api.github.com/repos/test-org/test-repo/pulls"
+        assert call_args[1]["headers"]["Authorization"] == "token test-token"
+
+        # Check PR data
+        pr_data = call_args[1]["json"]
+        assert pr_data["title"] == "Merging all-contributors across the org"
+        assert pr_data["base"] == "main"
+        assert pr_data["head"] == "merge-all-contributors/ABCD"
+
+        # Check body contains expected sections
+        assert "## Summary" in pr_data["body"]
+        assert "## Files Updated" in pr_data["body"]
+        assert "`.all-contributorsrc`" in pr_data["body"]
 
     @patch("all_all_contributors.github_api.patch_request")
     def test_updates_existing_pull_request(self, mock_patch):
@@ -288,17 +292,68 @@ class TestCreateUpdatePullRequest:
             github_token="test-token",
         )
 
-        mock_patch.assert_called_once_with(
-            "https://api.github.com/repos/test-org/test-repo/pulls/42",
-            headers={
-                "Accept": "application/vnd.github.v3+json",
-                "Authorization": "token test-token",
-            },
-            json={
-                "title": "Merging all-contributors across the org",
-                "body": "",
-                "base": "main",
-                "state": "open",
-            },
-            return_json=True,
+        # Verify the call
+        assert mock_patch.call_count == 1
+        call_args = mock_patch.call_args
+
+        # Check URL and headers
+        assert call_args[0][0] == "https://api.github.com/repos/test-org/test-repo/pulls/42"
+        assert call_args[1]["headers"]["Authorization"] == "token test-token"
+
+        # Check PR data
+        pr_data = call_args[1]["json"]
+        assert pr_data["title"] == "Merging all-contributors across the org"
+        assert pr_data["base"] == "main"
+        assert pr_data["state"] == "open"
+
+        # Check body contains expected sections
+        assert "## Summary" in pr_data["body"]
+        assert "## Files Updated" in pr_data["body"]
+
+    @patch("all_all_contributors.github_api.post_request")
+    def test_creates_pr_with_updated_files(self, mock_post):
+        """Test that PR body includes list of updated files when tables were generated"""
+        mock_post.return_value = {"number": 123}
+
+        github_api.create_update_pull_request(
+            "test-org",
+            "test-repo",
+            "main",
+            "merge-all-contributors/ABCD",
+            pr_exists=False,
+            pr_number=None,
+            github_token="test-token",
+            config_filepath=".all-contributorsrc",
+            updated_files=["README.md", "docs/CONTRIBUTORS.md"],
         )
+
+        # Verify the PR body includes the updated files
+        pr_data = mock_post.call_args[1]["json"]
+        assert "**Contributor tables generated:**" in pr_data["body"]
+        assert "`README.md`" in pr_data["body"]
+        assert "`docs/CONTRIBUTORS.md`" in pr_data["body"]
+        assert "manually" not in pr_data["body"]  # Should not show manual generation note
+
+    @patch("all_all_contributors.github_api.post_request")
+    def test_creates_pr_without_updated_files(self, mock_post):
+        """Test that PR body shows note when table generation was skipped"""
+        mock_post.return_value = {"number": 123}
+
+        github_api.create_update_pull_request(
+            "test-org",
+            "test-repo",
+            "main",
+            "merge-all-contributors/ABCD",
+            pr_exists=False,
+            pr_number=None,
+            github_token="test-token",
+            config_filepath=".all-contributorsrc",
+            updated_files=None,
+        )
+
+        # Verify the PR body includes note about manual generation
+        pr_data = mock_post.call_args[1]["json"]
+        assert "**Note:**" in pr_data["body"]
+        assert "manually" in pr_data["body"]
+        assert "all-contributors generate" in pr_data["body"]
+        assert "**Contributor tables generated:**" not in pr_data["body"]

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -263,7 +263,9 @@ class TestCreateUpdatePullRequest:
         call_args = mock_post.call_args
 
         # Check URL and headers
-        assert call_args[0][0] == "https://api.github.com/repos/test-org/test-repo/pulls"
+        assert (
+            call_args[0][0] == "https://api.github.com/repos/test-org/test-repo/pulls"
+        )
         assert call_args[1]["headers"]["Authorization"] == "token test-token"
 
         # Check PR data
@@ -297,7 +299,10 @@ class TestCreateUpdatePullRequest:
         call_args = mock_patch.call_args
 
         # Check URL and headers
-        assert call_args[0][0] == "https://api.github.com/repos/test-org/test-repo/pulls/42"
+        assert (
+            call_args[0][0]
+            == "https://api.github.com/repos/test-org/test-repo/pulls/42"
+        )
         assert call_args[1]["headers"]["Authorization"] == "token test-token"
 
         # Check PR data
@@ -332,7 +337,9 @@ class TestCreateUpdatePullRequest:
         assert "**Contributor tables generated:**" in pr_data["body"]
         assert "`README.md`" in pr_data["body"]
         assert "`docs/CONTRIBUTORS.md`" in pr_data["body"]
-        assert "manually" not in pr_data["body"]  # Should not show manual generation note
+        assert (
+            "manually" not in pr_data["body"]
+        )  # Should not show manual generation note
 
     @patch("all_all_contributors.github_api.post_request")
     def test_creates_pr_without_updated_files(self, mock_post):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -237,6 +237,7 @@ class TestWorkflowIntegration:
     @patch("all_all_contributors.cli.git_operations.create_commit")
     @patch("all_all_contributors.cli.git_operations.has_changes")
     @patch("all_all_contributors.cli.git_operations.stage_modified_files")
+    @patch("all_all_contributors.cli.contributor_table.generate_contributor_tables")
     @patch("builtins.open", new_callable=mock_open, read_data='{"contributors": []}')
     @patch("all_all_contributors.cli.inject_config")
     @patch("all_all_contributors.cli.git_operations.checkout_branch")
@@ -257,6 +258,7 @@ class TestWorkflowIntegration:
         mock_checkout,
         mock_inject,
         mock_file,
+        mock_generate_tables,
         mock_stage,
         mock_has_changes,
         mock_commit,
@@ -271,6 +273,7 @@ class TestWorkflowIntegration:
         mock_merge.return_value = [{"login": "user1"}]
         mock_find_pr.return_value = (False, "test-branch", None)
         mock_inject.return_value = {"contributors": [{"login": "user1"}]}
+        mock_generate_tables.return_value = None
         mock_has_changes.return_value = True
         mock_create_pr.return_value = None
 
@@ -288,5 +291,13 @@ class TestWorkflowIntegration:
         # Verify push happened before PR creation
         mock_push.assert_called_once_with("test-branch", "/test/repo")
         mock_create_pr.assert_called_once_with(
-            "test-org", "test-repo", "main", "test-branch", False, None, "test-token"
+            "test-org",
+            "test-repo",
+            "main",
+            "test-branch",
+            False,
+            None,
+            "test-token",
+            config_filepath=".all-contributorsrc",
+            updated_files=None,
         )


### PR DESCRIPTION
### Needs #93 merged first

### Summary

Enables running `all-contributors generate` so that tables are updated after the config files have been merged.

- fixes #5 

### What has changed?

- Dockerfile uses multi-stage build install all-contributors cli (node package)
- adds new functions to shell out to `all-contributors generate`
- descriptive commit messages and pull request bodies
- updated tests and docs

### What shoulda reviewer concentrate on?

- [ ] Everything looks okay?
